### PR TITLE
fix: 调整书签文件夹图标的展开时机

### DIFF
--- a/scripts/test-newtab-bookmark-folder-menu-state.js
+++ b/scripts/test-newtab-bookmark-folder-menu-state.js
@@ -152,12 +152,29 @@ const card = view.buildCard(
   { viewMode: 'list', menuMode: true }
 );
 
+card.dispatchEvent(createFakeEvent('pointerenter', { pointerType: 'mouse' }));
+assert.strictEqual(
+  card.classList.contains('x-nt-bookmark-card--hover'),
+  true,
+  'hovering a folder should activate its card visual state'
+);
+assert.deepStrictEqual(
+  morphStates,
+  [],
+  'hovering a folder should not expand its icon'
+);
+
 card.dispatchEvent(createFakeEvent('click'));
 assert.strictEqual(openedFolders.length, 1, 'clicking a list-mode folder should open its cascade menu');
 assert.strictEqual(
   card.classList.contains('x-nt-bookmark-card--hover'),
   true,
   'clicking a folder menu trigger should immediately set the active visual state'
+);
+assert.deepStrictEqual(
+  morphStates,
+  [true],
+  'clicking a folder should expand its icon as the menu opens'
 );
 
 card.setAttribute('aria-expanded', 'true');

--- a/src/newtab/bookmarks-view.js
+++ b/src/newtab/bookmarks-view.js
@@ -326,6 +326,7 @@
       let hoverIntentTimer = null;
       let isHoverVisualActive = false;
       let isMenuVisualLocked = false;
+      let isFolderIconExpanded = false;
       const clearHoverIntentTimer = () => {
         if (hoverIntentTimer !== null && windowObj) {
           windowObj.clearTimeout(hoverIntentTimer);
@@ -344,21 +345,28 @@
         }
         isHoverVisualActive = active;
         card.classList.toggle('x-nt-bookmark-card--hover', active);
-        if (folderIcon) {
-          playFolderPathMorph(folderIcon, active);
+      };
+      const setFolderIconExpanded = (active) => {
+        const nextActive = Boolean(active);
+        if (!folderIcon || isFolderIconExpanded === nextActive) {
+          return;
         }
+        isFolderIconExpanded = nextActive;
+        playFolderPathMorph(folderIcon, nextActive);
       };
       const setMenuVisualLocked = (active) => {
         const nextActive = Boolean(active);
         if (isMenuVisualLocked === nextActive) {
           if (nextActive) {
             setHoverVisualActive(true);
+            setFolderIconExpanded(true);
           }
           return;
         }
         isMenuVisualLocked = nextActive;
         clearHoverIntentTimer();
         setHoverVisualActive(nextActive);
+        setFolderIconExpanded(nextActive);
       };
       const deactivateBookmarkHoverVisual = () => {
         clearHoverIntentTimer();


### PR DESCRIPTION
## 问题

当前鼠标悬浮书签文件夹时，卡片选中态和文件夹图标展开动画会同时触发,不符合日常使用直觉

## 修改

- 将文件夹卡片悬浮状态与图标展开状态分离
- 鼠标悬浮时仅显示卡片选中态
- 点击文件夹时展开文件夹图标和书签列表
- 关闭书签列表时收起文件夹图标
- 添加回归测试，覆盖悬浮和点击时的动画状态

## 验证

- 书签文件夹菜单状态测试通过
- 书签级联菜单键盘测试通过
- JavaScript 语法检查通过
- `git diff --check` 通过

效果如下：
<img width="984" height="696" alt="屏幕录制 2026-07-16 135033" src="https://github.com/user-attachments/assets/3076d0b1-697d-4afd-b2b6-f875a9571021" />
