### PR TITLE
Fix README star history chart

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -1,0 +1,43 @@
+name: Update Star History
+
+on:
+  schedule:
+    - cron: "17 1 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: update-star-history-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate star history chart
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/update-star-history.js
+
+      - name: Commit chart when it changes
+        run: |
+          if git diff --quiet -- assets/star-history.svg; then
+            echo "Star history is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/star-history.svg
+          git commit -m "docs: update star history chart"
+          git push

--- a/README.en.md
+++ b/README.en.md
@@ -122,8 +122,8 @@ npm run test:onboarding-content
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/#kubai087/lumno-extension&Date">
-    <img src="https://api.star-history.com/svg?repos=kubai087/lumno-extension&type=Date" alt="Star History Chart" />
+  <a href="https://github.com/kubai087/lumno-extension/stargazers">
+    <img src="assets/star-history.svg" alt="GitHub Star History Chart" />
   </a>
 </p>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -122,8 +122,8 @@ npm run test:onboarding-content
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/#kubai087/lumno-extension&Date">
-    <img src="https://api.star-history.com/svg?repos=kubai087/lumno-extension&type=Date" alt="Star History Chart" />
+  <a href="https://github.com/kubai087/lumno-extension/stargazers">
+    <img src="assets/star-history.svg" alt="GitHub Star 履歴グラフ" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ npm run test:onboarding-content
 ## GitHub Star 变化
 
 <p align="center">
-  <a href="https://www.star-history.com/#kubai087/lumno-extension&Date">
-    <img src="https://api.star-history.com/svg?repos=kubai087/lumno-extension&type=Date" alt="Star History Chart" />
+  <a href="https://github.com/kubai087/lumno-extension/stargazers">
+    <img src="assets/star-history.svg" alt="GitHub Star 变化图" />
   </a>
 </p>
 

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="500" viewBox="0 0 960 500" role="img" aria-labelledby="title description">
+  <title id="title">kubai087/lumno-extension GitHub star growth</title>
+  <desc id="description">Cumulative GitHub stars over time. Current total: 142.</desc>
+  <defs>
+    <linearGradient id="area-gradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7c5cff" stop-opacity="0.34" />
+      <stop offset="100%" stop-color="#7c5cff" stop-opacity="0.03" />
+    </linearGradient>
+  </defs>
+  <style>
+    .background { fill: #ffffff; stroke: #d8dee4; }
+    .title { fill: #1f2328; font: 700 22px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .subtitle { fill: #656d76; font: 13px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .total { fill: #1f2328; font: 700 28px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .total-label { fill: #656d76; font: 12px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 0.08em; }
+    .grid { stroke: #d8dee4; stroke-width: 1; }
+    .tick { stroke: #8c959f; stroke-width: 1; }
+    .axis-label { fill: #656d76; font: 12px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .area { fill: url(#area-gradient); }
+    .line { fill: none; stroke: #6e40ff; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3; }
+    .marker-ring { fill: #ffffff; stroke: #6e40ff; stroke-width: 2; }
+    .marker { fill: #6e40ff; }
+  </style>
+  <rect class="background" x="0.5" y="0.5" width="959" height="499" rx="16" />
+  <text class="title" x="44" y="52">GitHub Star Growth</text>
+  <text class="subtitle" x="44" y="77">kubai087/lumno-extension · Latest star recorded Jul 2026</text>
+  <text class="total" x="916" y="52" text-anchor="end">142</text>
+  <text class="total-label" x="916" y="75" text-anchor="end">TOTAL STARS</text>
+  <line class="grid" x1="86" y1="414.00" x2="916" y2="414.00" />
+  <text class="axis-label" x="68" y="419" text-anchor="end">0</text>
+  <line class="grid" x1="86" y1="376.75" x2="916" y2="376.75" />
+  <text class="axis-label" x="68" y="381.75" text-anchor="end">20</text>
+  <line class="grid" x1="86" y1="339.50" x2="916" y2="339.50" />
+  <text class="axis-label" x="68" y="344.5" text-anchor="end">40</text>
+  <line class="grid" x1="86" y1="302.25" x2="916" y2="302.25" />
+  <text class="axis-label" x="68" y="307.25" text-anchor="end">60</text>
+  <line class="grid" x1="86" y1="265.00" x2="916" y2="265.00" />
+  <text class="axis-label" x="68" y="270" text-anchor="end">80</text>
+  <line class="grid" x1="86" y1="227.75" x2="916" y2="227.75" />
+  <text class="axis-label" x="68" y="232.75" text-anchor="end">100</text>
+  <line class="grid" x1="86" y1="190.50" x2="916" y2="190.50" />
+  <text class="axis-label" x="68" y="195.5" text-anchor="end">120</text>
+  <line class="grid" x1="86" y1="153.25" x2="916" y2="153.25" />
+  <text class="axis-label" x="68" y="158.25" text-anchor="end">140</text>
+  <line class="grid" x1="86" y1="116.00" x2="916" y2="116.00" />
+  <text class="axis-label" x="68" y="121" text-anchor="end">160</text>
+  <line class="tick" x1="86.00" y1="414" x2="86.00" y2="421" />
+  <text class="axis-label" x="86.00" y="445" text-anchor="middle">Jan 2026</text>
+  <line class="tick" x1="293.50" y1="414" x2="293.50" y2="421" />
+  <text class="axis-label" x="293.50" y="445" text-anchor="middle">Mar 2026</text>
+  <line class="tick" x1="501.00" y1="414" x2="501.00" y2="421" />
+  <text class="axis-label" x="501.00" y="445" text-anchor="middle">Apr 2026</text>
+  <line class="tick" x1="708.50" y1="414" x2="708.50" y2="421" />
+  <text class="axis-label" x="708.50" y="445" text-anchor="middle">Jun 2026</text>
+  <line class="tick" x1="916.00" y1="414" x2="916.00" y2="421" />
+  <text class="axis-label" x="916.00" y="445" text-anchor="middle">Jul 2026</text>
+  <path class="area" d="M 86.00 414 L 86.00 412.14 L 115.29 412.14 L 115.29 410.27 L 193.41 410.27 L 193.41 406.55 L 198.29 406.55 L 198.29 391.65 L 203.18 391.65 L 203.18 386.06 L 208.06 386.06 L 208.06 378.61 L 212.94 378.61 L 212.94 374.89 L 252.00 374.89 L 252.00 373.02 L 261.76 373.02 L 261.76 369.30 L 281.29 369.30 L 281.29 365.57 L 286.18 365.57 L 286.18 363.71 L 295.94 363.71 L 295.94 361.85 L 300.82 361.85 L 300.82 354.40 L 305.71 354.40 L 305.71 337.64 L 310.59 337.64 L 310.59 326.46 L 315.47 326.46 L 315.47 324.60 L 320.35 324.60 L 320.35 319.01 L 325.24 319.01 L 325.24 317.15 L 330.12 317.15 L 330.12 313.43 L 335.00 313.43 L 335.00 305.98 L 349.65 305.98 L 349.65 302.25 L 369.18 302.25 L 369.18 298.52 L 378.94 298.52 L 378.94 292.94 L 388.71 292.94 L 388.71 287.35 L 393.59 287.35 L 393.59 285.49 L 403.35 285.49 L 403.35 272.45 L 437.53 272.45 L 437.53 270.59 L 447.29 270.59 L 447.29 268.73 L 457.06 268.73 L 457.06 266.86 L 466.82 266.86 L 466.82 263.14 L 471.71 263.14 L 471.71 259.41 L 486.35 259.41 L 486.35 257.55 L 501.00 257.55 L 501.00 253.83 L 510.76 253.83 L 510.76 251.96 L 530.29 251.96 L 530.29 250.10 L 584.00 250.10 L 584.00 248.24 L 627.94 248.24 L 627.94 246.38 L 647.47 246.38 L 647.47 244.51 L 667.00 244.51 L 667.00 233.34 L 671.88 233.34 L 671.88 222.16 L 681.65 222.16 L 681.65 218.44 L 691.41 218.44 L 691.41 212.85 L 701.18 212.85 L 701.18 209.13 L 710.94 209.13 L 710.94 205.40 L 720.71 205.40 L 720.71 203.54 L 725.59 203.54 L 725.59 201.67 L 735.35 201.67 L 735.35 199.81 L 784.18 199.81 L 784.18 197.95 L 789.06 197.95 L 789.06 196.09 L 828.12 196.09 L 828.12 194.22 L 842.76 194.22 L 842.76 188.64 L 852.53 188.64 L 852.53 184.91 L 857.41 184.91 L 857.41 166.29 L 862.29 166.29 L 862.29 164.42 L 872.06 164.42 L 872.06 158.84 L 876.94 158.84 L 876.94 153.25 L 906.24 153.25 L 906.24 151.39 L 916.00 151.39 L 916.00 149.53 L 916.00 414 Z" />
+  <path class="line" d="M 86.00 414 L 86.00 412.14 L 115.29 412.14 L 115.29 410.27 L 193.41 410.27 L 193.41 406.55 L 198.29 406.55 L 198.29 391.65 L 203.18 391.65 L 203.18 386.06 L 208.06 386.06 L 208.06 378.61 L 212.94 378.61 L 212.94 374.89 L 252.00 374.89 L 252.00 373.02 L 261.76 373.02 L 261.76 369.30 L 281.29 369.30 L 281.29 365.57 L 286.18 365.57 L 286.18 363.71 L 295.94 363.71 L 295.94 361.85 L 300.82 361.85 L 300.82 354.40 L 305.71 354.40 L 305.71 337.64 L 310.59 337.64 L 310.59 326.46 L 315.47 326.46 L 315.47 324.60 L 320.35 324.60 L 320.35 319.01 L 325.24 319.01 L 325.24 317.15 L 330.12 317.15 L 330.12 313.43 L 335.00 313.43 L 335.00 305.98 L 349.65 305.98 L 349.65 302.25 L 369.18 302.25 L 369.18 298.52 L 378.94 298.52 L 378.94 292.94 L 388.71 292.94 L 388.71 287.35 L 393.59 287.35 L 393.59 285.49 L 403.35 285.49 L 403.35 272.45 L 437.53 272.45 L 437.53 270.59 L 447.29 270.59 L 447.29 268.73 L 457.06 268.73 L 457.06 266.86 L 466.82 266.86 L 466.82 263.14 L 471.71 263.14 L 471.71 259.41 L 486.35 259.41 L 486.35 257.55 L 501.00 257.55 L 501.00 253.83 L 510.76 253.83 L 510.76 251.96 L 530.29 251.96 L 530.29 250.10 L 584.00 250.10 L 584.00 248.24 L 627.94 248.24 L 627.94 246.38 L 647.47 246.38 L 647.47 244.51 L 667.00 244.51 L 667.00 233.34 L 671.88 233.34 L 671.88 222.16 L 681.65 222.16 L 681.65 218.44 L 691.41 218.44 L 691.41 212.85 L 701.18 212.85 L 701.18 209.13 L 710.94 209.13 L 710.94 205.40 L 720.71 205.40 L 720.71 203.54 L 725.59 203.54 L 725.59 201.67 L 735.35 201.67 L 735.35 199.81 L 784.18 199.81 L 784.18 197.95 L 789.06 197.95 L 789.06 196.09 L 828.12 196.09 L 828.12 194.22 L 842.76 194.22 L 842.76 188.64 L 852.53 188.64 L 852.53 184.91 L 857.41 184.91 L 857.41 166.29 L 862.29 166.29 L 862.29 164.42 L 872.06 164.42 L 872.06 158.84 L 876.94 158.84 L 876.94 153.25 L 906.24 153.25 L 906.24 151.39 L 916.00 151.39 L 916.00 149.53" />
+  <circle class="marker-ring" cx="916.00" cy="149.53" r="8" />
+    <circle class="marker" cx="916.00" cy="149.53" r="4" />
+</svg>

--- a/scripts/update-star-history.js
+++ b/scripts/update-star-history.js
@@ -1,0 +1,201 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repository = process.env.GITHUB_REPOSITORY || "kubai087/lumno-extension";
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const outputPath = path.join(__dirname, "..", "assets", "star-history.svg");
+
+if (!token) {
+  console.error("GITHUB_TOKEN or GH_TOKEN is required to read stargazer timestamps.");
+  process.exit(1);
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function niceStep(value) {
+  if (value <= 0) return 1;
+
+  const exponent = Math.floor(Math.log10(value));
+  const fraction = value / 10 ** exponent;
+  let niceFraction;
+
+  if (fraction < 1.5) niceFraction = 1;
+  else if (fraction < 3) niceFraction = 2;
+  else if (fraction < 7) niceFraction = 5;
+  else niceFraction = 10;
+
+  return niceFraction * 10 ** exponent;
+}
+
+function formatDate(timestamp) {
+  return new Intl.DateTimeFormat("en", {
+    year: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(timestamp));
+}
+
+async function fetchStargazers() {
+  const timestamps = [];
+
+  for (let page = 1; ; page += 1) {
+    const url = new URL(`https://api.github.com/repos/${repository}/stargazers`);
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github.star+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "lumno-star-history-workflow",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub stargazers request failed with HTTP ${response.status}.`);
+    }
+
+    const pageItems = await response.json();
+    for (const item of pageItems) {
+      if (item.starred_at) timestamps.push(item.starred_at);
+    }
+
+    if (pageItems.length < 100) break;
+  }
+
+  return timestamps.sort();
+}
+
+function renderChart(timestamps) {
+  const width = 960;
+  const height = 500;
+  const plot = { left: 86, right: 916, top: 116, bottom: 414 };
+  const safeRepository = escapeXml(repository);
+
+  const totalsByDay = new Map();
+  for (const timestamp of timestamps) {
+    const day = timestamp.slice(0, 10);
+    totalsByDay.set(day, (totalsByDay.get(day) || 0) + 1);
+  }
+
+  let runningTotal = 0;
+  const dailyTotals = [...totalsByDay].map(([day, count]) => {
+    runningTotal += count;
+    return { day, total: runningTotal };
+  });
+
+  const fallbackDay = new Date().toISOString().slice(0, 10);
+  const firstDay = dailyTotals[0]?.day || fallbackDay;
+  const lastDay = dailyTotals.at(-1)?.day || fallbackDay;
+  const firstTime = Date.parse(`${firstDay}T00:00:00Z`);
+  const rawLastTime = Date.parse(`${lastDay}T00:00:00Z`);
+  const lastTime = rawLastTime === firstTime ? firstTime + 86_400_000 : rawLastTime;
+  const totalStars = timestamps.length;
+  const yStep = niceStep(Math.max(totalStars, 1) / 5);
+  const yMax = Math.max(yStep, Math.ceil(Math.max(totalStars, 1) / yStep) * yStep);
+  const xScale = (timestamp) =>
+    plot.left + ((timestamp - firstTime) / (lastTime - firstTime)) * (plot.right - plot.left);
+  const yScale = (value) =>
+    plot.bottom - (value / yMax) * (plot.bottom - plot.top);
+
+  const points = dailyTotals.map(({ day, total }) => ({
+    x: xScale(Date.parse(`${day}T00:00:00Z`)),
+    y: yScale(total),
+  }));
+
+  let linePath = "";
+  let areaPath = "";
+  if (points.length > 0) {
+    linePath = `M ${points[0].x.toFixed(2)} ${plot.bottom} L ${points[0].x.toFixed(2)} ${points[0].y.toFixed(2)}`;
+    for (let index = 1; index < points.length; index += 1) {
+      linePath += ` L ${points[index].x.toFixed(2)} ${points[index - 1].y.toFixed(2)}`;
+      linePath += ` L ${points[index].x.toFixed(2)} ${points[index].y.toFixed(2)}`;
+    }
+    areaPath = `${linePath} L ${points.at(-1).x.toFixed(2)} ${plot.bottom} Z`;
+  }
+
+  const yTicks = [];
+  for (let value = 0; value <= yMax; value += yStep) {
+    const y = yScale(value).toFixed(2);
+    yTicks.push(
+      `  <line class="grid" x1="${plot.left}" y1="${y}" x2="${plot.right}" y2="${y}" />\n` +
+        `  <text class="axis-label" x="${plot.left - 18}" y="${Number(y) + 5}" text-anchor="end">${value}</text>`
+    );
+  }
+
+  const xTicks = [];
+  const xTickCount = 5;
+  for (let index = 0; index < xTickCount; index += 1) {
+    const ratio = index / (xTickCount - 1);
+    const timestamp = firstTime + (lastTime - firstTime) * ratio;
+    const x = xScale(timestamp).toFixed(2);
+    xTicks.push(
+      `  <line class="tick" x1="${x}" y1="${plot.bottom}" x2="${x}" y2="${plot.bottom + 7}" />\n` +
+        `  <text class="axis-label" x="${x}" y="${plot.bottom + 31}" text-anchor="middle">${escapeXml(formatDate(timestamp))}</text>`
+    );
+  }
+
+  const latestPoint = points.at(-1);
+  const latestMarker = latestPoint
+    ? `<circle class="marker-ring" cx="${latestPoint.x.toFixed(2)}" cy="${latestPoint.y.toFixed(2)}" r="8" />
+    <circle class="marker" cx="${latestPoint.x.toFixed(2)}" cy="${latestPoint.y.toFixed(2)}" r="4" />`
+    : "";
+  const statusText = totalStars
+    ? `Latest star recorded ${formatDate(rawLastTime)}`
+    : "No stars recorded yet";
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="960" height="500" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="title description">
+  <title id="title">${safeRepository} GitHub star growth</title>
+  <desc id="description">Cumulative GitHub stars over time. Current total: ${totalStars}.</desc>
+  <defs>
+    <linearGradient id="area-gradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7c5cff" stop-opacity="0.34" />
+      <stop offset="100%" stop-color="#7c5cff" stop-opacity="0.03" />
+    </linearGradient>
+  </defs>
+  <style>
+    .background { fill: #ffffff; stroke: #d8dee4; }
+    .title { fill: #1f2328; font: 700 22px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .subtitle { fill: #656d76; font: 13px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .total { fill: #1f2328; font: 700 28px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .total-label { fill: #656d76; font: 12px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 0.08em; }
+    .grid { stroke: #d8dee4; stroke-width: 1; }
+    .tick { stroke: #8c959f; stroke-width: 1; }
+    .axis-label { fill: #656d76; font: 12px ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .area { fill: url(#area-gradient); }
+    .line { fill: none; stroke: #6e40ff; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3; }
+    .marker-ring { fill: #ffffff; stroke: #6e40ff; stroke-width: 2; }
+    .marker { fill: #6e40ff; }
+  </style>
+  <rect class="background" x="0.5" y="0.5" width="959" height="499" rx="16" />
+  <text class="title" x="44" y="52">GitHub Star Growth</text>
+  <text class="subtitle" x="44" y="77">${safeRepository} · ${escapeXml(statusText)}</text>
+  <text class="total" x="916" y="52" text-anchor="end">${totalStars}</text>
+  <text class="total-label" x="916" y="75" text-anchor="end">TOTAL STARS</text>
+${yTicks.join("\n")}
+${xTicks.join("\n")}
+  ${areaPath ? `<path class="area" d="${areaPath}" />` : ""}
+  ${linePath ? `<path class="line" d="${linePath}" />` : ""}
+  ${latestMarker}
+</svg>
+`;
+}
+
+async function main() {
+  const timestamps = await fetchStargazers();
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, renderChart(timestamps));
+  console.log(`Updated ${path.relative(process.cwd(), outputPath)} with ${timestamps.length} stars.`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changed

- replace the broken third-party Star History embeds in all three READMEs with a repository-owned SVG chart
- add a Node.js generator that reads authenticated GitHub stargazer timestamps
- add a daily GitHub Actions workflow that regenerates and commits the chart only when it changes

## Why

GitHub restricted access to the public stargazers timeline, causing the external Star History endpoint used by the README to return HTTP 500. Generating the chart with the repository's own GitHub Actions token keeps the history visible without exposing a personal token.

## Validation

- generated the chart from the live repository data (142 stars)
- verified deterministic generation
- validated JavaScript syntax, SVG XML, workflow YAML, README references, and `git diff --check`
