### PR TITLE
feat: add quick hover copy action for bookmark URLs

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1034,6 +1034,15 @@
   "bookmarks_open_manager": {
     "message": "Open bookmark manager"
   },
+  "bookmarks_copy_url": {
+    "message": "Copy link"
+  },
+  "bookmarks_copy_url_success": {
+    "message": "Bookmark link copied"
+  },
+  "bookmarks_copy_url_failed": {
+    "message": "Could not copy link"
+  },
   "search_tag_history": {
     "message": "History"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1034,6 +1034,15 @@
   "bookmarks_open_manager": {
     "message": "ブックマークマネージャーを開く"
   },
+  "bookmarks_copy_url": {
+    "message": "リンクをコピー"
+  },
+  "bookmarks_copy_url_success": {
+    "message": "ブックマークのリンクをコピーしました"
+  },
+  "bookmarks_copy_url_failed": {
+    "message": "リンクをコピーできませんでした"
+  },
   "search_tag_history": {
     "message": "履歴"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1034,6 +1034,15 @@
   "bookmarks_open_manager": {
     "message": "打开书签管理页"
   },
+  "bookmarks_copy_url": {
+    "message": "复制链接"
+  },
+  "bookmarks_copy_url_success": {
+    "message": "已复制书签链接"
+  },
+  "bookmarks_copy_url_failed": {
+    "message": "复制链接失败，请重试"
+  },
   "search_tag_history": {
     "message": "历史"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1034,6 +1034,15 @@
   "bookmarks_open_manager": {
     "message": "開啟書籤管理頁"
   },
+  "bookmarks_copy_url": {
+    "message": "複製連結"
+  },
+  "bookmarks_copy_url_success": {
+    "message": "已複製書籤連結"
+  },
+  "bookmarks_copy_url_failed": {
+    "message": "複製連結失敗，請重試"
+  },
   "search_tag_history": {
     "message": "歷史"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test:newtab-bookmark-cascade-hover-intent": "node scripts/test-newtab-bookmark-cascade-hover-intent.js",
     "test:newtab-bookmark-cascade-keyboard": "node scripts/test-newtab-bookmark-cascade-keyboard.js",
     "test:newtab-bookmark-folder-menu-state": "node scripts/test-newtab-bookmark-folder-menu-state.js",
+    "test:newtab-bookmark-copy-action": "node scripts/test-newtab-bookmark-copy-action.js",
     "test:newtab-feedback-popover": "node scripts/test-newtab-feedback-popover.js",
     "test:newtab-section-mode-menus": "node scripts/test-newtab-section-mode-menus.js",
     "test:newtab-shortcuts-ui": "node scripts/test-newtab-shortcuts-ui.js",

--- a/scripts/test-newtab-bookmark-card-cursor-tooltips.js
+++ b/scripts/test-newtab-bookmark-card-cursor-tooltips.js
@@ -47,8 +47,13 @@ assertContains(
 );
 assertContains(
   bookmarksView,
-  'shouldShow: () => isBookmarkTitleTruncated(title)',
+  'return isBookmarkTitleTruncated(title);',
   'bookmark card cursor tooltips should only show for truncated titles'
+);
+assertContains(
+  bookmarksView,
+  "eventTarget.closest('.x-nt-bookmark-copy-action')",
+  'bookmark card cursor tooltips should stay hidden over the copy action'
 );
 assert.ok(
   !bookmarksView.includes('getTagText: isFolder ? null : getBackgroundOpenTagText'),

--- a/scripts/test-newtab-bookmark-copy-action.js
+++ b/scripts/test-newtab-bookmark-copy-action.js
@@ -161,13 +161,13 @@ function testCopyActionIntegration() {
 
   assert.match(
     html,
-    /\.x-nt-bookmark-card\[data-bookmark-copy-action-visible="true"\] \.x-nt-bookmark-title[\s\S]*?mask-image:/,
-    'Visible copy actions should fade the tail of long card titles'
+    /\.x-nt-bookmark-card\[data-bookmark-copy-action-visible="true"\] \.x-nt-bookmark-title[\s\S]*?padding-right:\s*30px/,
+    'Visible copy actions should reserve space before long card titles are truncated'
   );
   assert.match(
     html,
-    /\.x-nt-bookmark-cascade-row\[data-bookmark-copy-action-visible="true"\] \.x-nt-bookmark-cascade-label[\s\S]*?mask-image:/,
-    'Visible cascade copy actions should fade the tail of long labels'
+    /\.x-nt-bookmark-cascade-row\[data-bookmark-copy-action-visible="true"\] \.x-nt-bookmark-cascade-label[\s\S]*?padding-right:\s*28px/,
+    'Visible cascade copy actions should reserve space before long labels are truncated'
   );
   assert.match(cascadeSource, /x-nt-bookmark-cascade-copy-action/);
   assert.match(newtabSource, /copyUrl: copyBookmarkUrl/);

--- a/scripts/test-newtab-bookmark-copy-action.js
+++ b/scripts/test-newtab-bookmark-copy-action.js
@@ -1,0 +1,187 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+require(path.join('..', 'src', 'newtab', 'bookmarks-view.js'));
+
+const repoRoot = path.resolve(__dirname, '..');
+const { createBookmarksView } = globalThis.LumnoNewtabBookmarksView;
+
+function createElement(tagName) {
+  const listeners = new Map();
+  const attributes = new Map();
+  const classes = new Set();
+  const element = {
+    tagName: String(tagName || '').toUpperCase(),
+    children: [],
+    style: {
+      setProperty() {}
+    },
+    classList: {
+      add(...names) {
+        names.forEach((name) => classes.add(name));
+      },
+      remove(...names) {
+        names.forEach((name) => classes.delete(name));
+      },
+      toggle(name, force) {
+        if (force) {
+          classes.add(name);
+        } else {
+          classes.delete(name);
+        }
+      },
+      contains(name) {
+        return classes.has(name);
+      }
+    },
+    set className(value) {
+      classes.clear();
+      String(value || '').split(/\s+/).filter(Boolean).forEach((name) => classes.add(name));
+    },
+    get className() {
+      return Array.from(classes).join(' ');
+    },
+    appendChild(child) {
+      child.parentNode = element;
+      element.children.push(child);
+      return child;
+    },
+    setAttribute(name, value) {
+      attributes.set(name, String(value));
+    },
+    getAttribute(name) {
+      return attributes.get(name) || '';
+    },
+    removeAttribute(name) {
+      attributes.delete(name);
+    },
+    addEventListener(type, listener) {
+      listeners.set(type, [...(listeners.get(type) || []), listener]);
+    },
+    dispatch(type, values) {
+      const event = Object.assign({
+        type,
+        target: element,
+        preventDefault() {},
+        stopPropagation() {}
+      }, values || {});
+      (listeners.get(type) || []).forEach((listener) => listener(event));
+    },
+    querySelector(selector) {
+      const className = selector.startsWith('.') ? selector.slice(1) : '';
+      const visit = (node) => {
+        if (className && node.classList && node.classList.contains(className)) {
+          return node;
+        }
+        for (const child of node.children || []) {
+          const match = visit(child);
+          if (match) {
+            return match;
+          }
+        }
+        return null;
+      };
+      return visit(element);
+    }
+  };
+  return element;
+}
+
+function createView(copyCalls) {
+  return createBookmarksView({
+    documentObj: { createElement },
+    windowObj: { setTimeout, clearTimeout },
+    t: (_key, fallback) => fallback || '',
+    formatMessage: (_key, fallback, values) => fallback.replace('{title}', values.title),
+    sanitizeDisplayText: (value) => String(value || ''),
+    getHostFromUrl: () => 'example.com',
+    getSiteDisplayName: (_host, title) => title,
+    getUrlDisplay: (url) => url,
+    getRiSvg: () => '<svg></svg>',
+    getFigmaFolderSvg: () => '<svg></svg>',
+    initFolderPathMorph() {},
+    playFolderPathMorph() {},
+    attachFaviconWithFallbacks() {},
+    getImmediateThemeForSuggestion: () => null,
+    queueThemeForTarget() {},
+    applyCardTheme() {},
+    bindCursorTooltip() {},
+    hideCursorTooltip() {},
+    shouldDelayHoverFromRecent: () => false,
+    openUrl() {},
+    openFolder() {},
+    openFolderMenu() {},
+    copyUrl(url) {
+      copyCalls.push(url);
+      return Promise.resolve(true);
+    }
+  });
+}
+
+async function testBookmarkCopyAction() {
+  const copyCalls = [];
+  const card = createView(copyCalls).buildCard({
+    id: 'docs',
+    type: 'bookmark',
+    title: 'A very long bookmark title',
+    url: 'https://example.com/docs'
+  }, 0, { menuMode: false });
+  const copyButton = card.querySelector('.x-nt-bookmark-copy-action');
+
+  assert.ok(copyButton, 'URL bookmarks should render a copy action');
+  assert.strictEqual(card.getAttribute('data-bookmark-copy-action-visible'), '');
+
+  copyButton.dispatch('pointerenter');
+  assert.strictEqual(card.getAttribute('data-bookmark-copy-action-visible'), 'true');
+
+  copyButton.dispatch('click');
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepStrictEqual(copyCalls, ['https://example.com/docs']);
+
+  copyButton.dispatch('pointerleave');
+  assert.strictEqual(card.getAttribute('data-bookmark-copy-action-visible'), '');
+}
+
+function testFoldersDoNotRenderCopyAction() {
+  const card = createView([]).buildCard({
+    id: 'folder',
+    type: 'folder',
+    title: 'Folder'
+  }, 0, { menuMode: true });
+
+  assert.strictEqual(card.querySelector('.x-nt-bookmark-copy-action'), null);
+}
+
+function testCopyActionIntegration() {
+  const html = fs.readFileSync(path.join(repoRoot, 'src/newtab/newtab.html'), 'utf8');
+  const cascadeSource = fs.readFileSync(path.join(repoRoot, 'src/newtab/bookmark-cascade-menu.js'), 'utf8');
+  const newtabSource = fs.readFileSync(path.join(repoRoot, 'src/newtab/newtab.js'), 'utf8');
+
+  assert.match(
+    html,
+    /\.x-nt-bookmark-card\[data-bookmark-copy-action-visible="true"\] \.x-nt-bookmark-title[\s\S]*?mask-image:/,
+    'Visible copy actions should fade the tail of long card titles'
+  );
+  assert.match(
+    html,
+    /\.x-nt-bookmark-cascade-row\[data-bookmark-copy-action-visible="true"\] \.x-nt-bookmark-cascade-label[\s\S]*?mask-image:/,
+    'Visible cascade copy actions should fade the tail of long labels'
+  );
+  assert.match(cascadeSource, /x-nt-bookmark-cascade-copy-action/);
+  assert.match(newtabSource, /copyUrl: copyBookmarkUrl/);
+  assert.doesNotMatch(html, /bookmark-context-menu\.js/);
+}
+
+Promise.resolve()
+  .then(testBookmarkCopyAction)
+  .then(() => {
+    testFoldersDoNotRenderCopyAction();
+    testCopyActionIntegration();
+    process.stdout.write('newtab bookmark copy action tests passed\n');
+  })
+  .catch((error) => {
+    process.stderr.write(`${error.stack || error}\n`);
+    process.exit(1);
+  });

--- a/src/newtab/bookmark-cascade-menu.js
+++ b/src/newtab/bookmark-cascade-menu.js
@@ -87,6 +87,9 @@
     const hideCursorTooltip = getFunction(config, 'hideCursorTooltip');
     const showTopActionTooltip = getFunction(config, 'showTopActionTooltip');
     const hideTopActionTooltip = getFunction(config, 'hideTopActionTooltip');
+    const copyUrl = getFunction(config, 'copyUrl', function() {
+      return Promise.resolve(false);
+    });
     const shouldSuppressHover = getFunction(config, 'shouldSuppressHover', function() {
       return false;
     });
@@ -1193,6 +1196,9 @@
         }
         const isFolder = item.type === 'folder';
         const titleText = item.title || (item.url ? getUrlDisplay(item.url) : t('bookmarks_heading', 'Bookmarks'));
+        const itemRow = documentObj.createElement('div');
+        itemRow.className = 'x-nt-bookmark-cascade-row';
+        itemRow.setAttribute('role', 'none');
         const itemButton = documentObj.createElement('button');
         itemButton.type = 'button';
         itemButton.className = 'x-nt-bookmark-cascade-item';
@@ -1210,6 +1216,7 @@
           itemButton.appendChild(icon);
         }
         itemButton.appendChild(label);
+        itemRow.appendChild(itemButton);
 
         const openNestedLevel = (openOptions) => {
           if (!isFolder) {
@@ -1258,6 +1265,7 @@
         });
 
         if (isFolder) {
+          itemRow.classList.add('x-nt-bookmark-cascade-row--folder');
           itemButton.classList.add('x-nt-bookmark-cascade-item--folder');
           itemButton.setAttribute('aria-haspopup', 'menu');
           itemButton.setAttribute('aria-expanded', 'false');
@@ -1300,6 +1308,51 @@
             }
           });
         } else {
+          const copyButton = documentObj.createElement('button');
+          let copyActionFocused = false;
+          const setCopyActionVisible = (visible) => {
+            if (visible) {
+              itemRow.setAttribute('data-bookmark-copy-action-visible', 'true');
+            } else {
+              itemRow.removeAttribute('data-bookmark-copy-action-visible');
+            }
+          };
+          copyButton.type = 'button';
+          copyButton.className = 'x-nt-bookmark-copy-action x-nt-bookmark-cascade-copy-action';
+          copyButton.innerHTML = getRiSvg('ri-file-copy-line', 'ri-size-16');
+          copyButton.setAttribute('aria-label', t('bookmarks_copy_url', 'Copy link'));
+          copyButton.addEventListener('pointerenter', () => {
+            cancelBookmarkCascadeHoverIntent();
+            hideCursorTooltip();
+            activateLeafItem();
+            setCopyActionVisible(true);
+          });
+          copyButton.addEventListener('pointerleave', () => {
+            if (!copyActionFocused) {
+              setCopyActionVisible(false);
+            }
+          });
+          copyButton.addEventListener('focus', () => {
+            copyActionFocused = true;
+            cancelBookmarkCascadeHoverIntent();
+            hideCursorTooltip();
+            activateLeafItem();
+            setCopyActionVisible(true);
+          });
+          copyButton.addEventListener('blur', () => {
+            copyActionFocused = false;
+            setCopyActionVisible(false);
+          });
+          copyButton.addEventListener('pointerdown', (event) => {
+            event.stopPropagation();
+          });
+          copyButton.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            hideCursorTooltip();
+            Promise.resolve().then(() => copyUrl(item.url)).catch(noop);
+          });
+          itemRow.appendChild(copyButton);
           bindCursorTooltip(itemButton, () => titleText, {
             maxWidth: 460,
             shouldShow: (_target, event) => shouldOpenUrlInBackground(event)
@@ -1314,6 +1367,11 @@
             }, event);
           });
           itemButton.addEventListener('pointerleave', (event) => {
+            if (event && event.relatedTarget &&
+                typeof itemRow.contains === 'function' &&
+                itemRow.contains(event.relatedTarget)) {
+              return;
+            }
             cancelBookmarkCascadeHoverIntentFor(itemButton);
             setBookmarkCascadeItemHoverSuppressed(itemButton, false);
             clearBookmarkCascadePointerActiveItem(levelElement, null, event);
@@ -1341,7 +1399,7 @@
             navigateLeafItem(event);
           });
         }
-        contentElement.appendChild(itemButton);
+        contentElement.appendChild(itemRow);
       });
 
       bookmarkCascadeMenu.appendChild(levelElement);

--- a/src/newtab/bookmarks-view.js
+++ b/src/newtab/bookmarks-view.js
@@ -137,6 +137,9 @@
     const hideCursorTooltip = getFunction(options, 'hideCursorTooltip');
     const openFolder = getFunction(options, 'openFolder');
     const openFolderMenu = getFunction(options, 'openFolderMenu');
+    const copyUrl = getFunction(options, 'copyUrl', function() {
+      return Promise.resolve(false);
+    });
     const navigateToUrl = getFunction(options, 'navigateToUrl');
     const openUrl = getFunction(options, 'openUrl', function(url) {
       navigateToUrl(url);
@@ -223,9 +226,10 @@
       const host = item.host || getHostFromUrl(themeUrl) || '';
       const siteName = getSiteDisplayName(host, item.title);
       const titleText = item.title || siteName || (item.url ? getUrlDisplay(item.url) : t('bookmarks_heading', '书签'));
-      const card = documentObj.createElement('button');
-      card.type = 'button';
+      const card = documentObj.createElement('div');
       card.className = 'x-nt-bookmark-card';
+      card.tabIndex = 0;
+      card.setAttribute('role', 'button');
       card.draggable = false;
       if (isFolder) {
         card.classList.add('x-nt-bookmark-card--folder');
@@ -289,6 +293,52 @@
 
       card.appendChild(icon);
       card.appendChild(title);
+      if (!isFolder) {
+        const copyButton = documentObj.createElement('button');
+        let copyActionFocused = false;
+        const setCopyActionVisible = (visible) => {
+          if (visible) {
+            card.setAttribute('data-bookmark-copy-action-visible', 'true');
+          } else {
+            card.removeAttribute('data-bookmark-copy-action-visible');
+          }
+        };
+        copyButton.type = 'button';
+        copyButton.className = 'x-nt-bookmark-copy-action';
+        copyButton.innerHTML = getRiSvg('ri-file-copy-line', 'ri-size-16');
+        copyButton.setAttribute('aria-label', t('bookmarks_copy_url', 'Copy link'));
+        copyButton.addEventListener('pointerenter', () => {
+          hideCursorTooltip();
+          setCopyActionVisible(true);
+        });
+        copyButton.addEventListener('pointerleave', () => {
+          if (!copyActionFocused) {
+            setCopyActionVisible(false);
+          }
+        });
+        copyButton.addEventListener('focus', () => {
+          copyActionFocused = true;
+          hideCursorTooltip();
+          setCopyActionVisible(true);
+        });
+        copyButton.addEventListener('blur', () => {
+          copyActionFocused = false;
+          setCopyActionVisible(false);
+        });
+        copyButton.addEventListener('pointerdown', (event) => {
+          event.stopPropagation();
+        });
+        copyButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          hideCursorTooltip();
+          Promise.resolve().then(() => copyUrl(item.url)).catch(noop);
+        });
+        copyButton.addEventListener('keydown', (event) => {
+          event.stopPropagation();
+        });
+        card.appendChild(copyButton);
+      }
       if (isFolder && Array.isArray(item.previewUrls) && item.previewUrls.length > 0) {
         const previewWrap = documentObj.createElement('span');
         previewWrap.className = 'x-nt-folder-preview';
@@ -395,6 +445,7 @@
         isHoverVisualActive = false;
         isMenuVisualLocked = false;
         card.classList.remove('x-nt-bookmark-card--hover');
+        card.removeAttribute('data-bookmark-copy-action-visible');
         setFolderExpanded(false);
       };
       if (isFolder && menuMode) {
@@ -445,7 +496,14 @@
       });
       bindCursorTooltip(card, () => card._xTitleText || titleText, {
         maxWidth: 460,
-        shouldShow: () => isBookmarkTitleTruncated(title)
+        shouldShow: (_target, event) => {
+          const eventTarget = event && event.target;
+          if (eventTarget && typeof eventTarget.closest === 'function' &&
+              eventTarget.closest('.x-nt-bookmark-copy-action')) {
+            return false;
+          }
+          return isBookmarkTitleTruncated(title);
+        }
       });
       card.addEventListener('click', (event) => {
         if (card._xBookmarkSuppressClick) {

--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -1595,6 +1595,49 @@
         overflow: hidden;
         text-overflow: ellipsis;
       }
+      .x-nt-bookmark-copy-action {
+        all: unset;
+        position: absolute;
+        right: 7px;
+        top: 50%;
+        z-index: 3;
+        width: 30px;
+        height: 30px;
+        border-radius: 9px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        color: var(--x-nt-bookmark-title, #475569);
+        opacity: 0;
+        transform: translate3d(5px, -50%, 0) scale(0.92);
+        pointer-events: auto;
+        cursor: pointer;
+        transition:
+          opacity 140ms ease,
+          transform 180ms cubic-bezier(0.22, 1, 0.36, 1),
+          color 140ms ease;
+      }
+      .x-nt-bookmark-card[data-bookmark-copy-action-visible="true"] .x-nt-bookmark-copy-action,
+      .x-nt-bookmark-copy-action:focus-visible {
+        opacity: 1;
+        transform: translate3d(0, -50%, 0) scale(1);
+      }
+      .x-nt-bookmark-copy-action:hover,
+      .x-nt-bookmark-copy-action:focus-visible {
+        color: color-mix(in srgb, var(--x-nt-bookmark-title, #475569) 72%, #2563eb);
+      }
+      .x-nt-bookmark-card[data-bookmark-copy-action-visible="true"] .x-nt-bookmark-title {
+        -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 36px), transparent 100%);
+        mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 36px), transparent 100%);
+      }
+      body[data-theme="dark"] .x-nt-bookmark-copy-action {
+        color: #cbd5e1;
+      }
+      body[data-theme="dark"] .x-nt-bookmark-copy-action:hover,
+      body[data-theme="dark"] .x-nt-bookmark-copy-action:focus-visible {
+        color: #f8fafc;
+      }
       .x-nt-folder-preview {
         display: inline-flex;
         align-items: center;
@@ -1835,6 +1878,12 @@
         cursor: default;
         user-select: none;
       }
+      .x-nt-bookmark-cascade-row {
+        position: relative;
+        flex: 0 0 auto;
+        width: 100%;
+        min-height: 32px;
+      }
       .x-nt-bookmark-cascade-item {
         all: unset;
         flex: 0 0 auto;
@@ -1850,6 +1899,21 @@
         cursor: pointer;
         white-space: nowrap;
         transition: color 120ms ease;
+      }
+      .x-nt-bookmark-cascade-row .x-nt-bookmark-cascade-copy-action {
+        right: 3px;
+        width: 28px;
+        height: 28px;
+        border-radius: 8px;
+        color: #64748b;
+      }
+      .x-nt-bookmark-cascade-row[data-bookmark-copy-action-visible="true"] .x-nt-bookmark-cascade-copy-action {
+        opacity: 1;
+        transform: translate3d(0, -50%, 0) scale(1);
+      }
+      .x-nt-bookmark-cascade-row[data-bookmark-copy-action-visible="true"] .x-nt-bookmark-cascade-label {
+        -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 32px), transparent 100%);
+        mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 32px), transparent 100%);
       }
       .x-nt-bookmark-cascade-item:hover,
       .x-nt-bookmark-cascade-item:focus-visible,
@@ -1954,6 +2018,9 @@
       body[data-theme="dark"] .x-nt-bookmark-cascade-item[data-hover-suppressed="true"]:hover:not([data-active="true"]) {
         background: transparent;
         color: #d6dbe3;
+      }
+      body[data-theme="dark"] .x-nt-bookmark-cascade-row .x-nt-bookmark-cascade-copy-action {
+        color: #cbd5e1;
       }
       body[data-theme="dark"] .x-nt-bookmark-cascade-icon--folder,
       body[data-theme="dark"] .x-nt-bookmark-cascade-arrow,
@@ -3030,6 +3097,7 @@
         background: #18181b;
       }
       @media (prefers-reduced-motion: reduce) {
+        .x-nt-bookmark-copy-action,
         .x-nt-feedback-popover,
         .x-nt-feedback-action,
         .x-nt-feedback-menu,

--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -1628,8 +1628,8 @@
         color: color-mix(in srgb, var(--x-nt-bookmark-title, #475569) 72%, #2563eb);
       }
       .x-nt-bookmark-card[data-bookmark-copy-action-visible="true"] .x-nt-bookmark-title {
-        -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 36px), transparent 100%);
-        mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 36px), transparent 100%);
+        box-sizing: border-box;
+        padding-right: 30px;
       }
       body[data-theme="dark"] .x-nt-bookmark-copy-action {
         color: #cbd5e1;
@@ -1912,8 +1912,8 @@
         transform: translate3d(0, -50%, 0) scale(1);
       }
       .x-nt-bookmark-cascade-row[data-bookmark-copy-action-visible="true"] .x-nt-bookmark-cascade-label {
-        -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 32px), transparent 100%);
-        mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 32px), transparent 100%);
+        box-sizing: border-box;
+        padding-right: 28px;
       }
       .x-nt-bookmark-cascade-item:hover,
       .x-nt-bookmark-cascade-item:focus-visible,

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -6953,6 +6953,7 @@
     hideCursorTooltip,
     openFolder: openBookmarkFolder,
     openFolderMenu: openBookmarkCascadeMenu,
+    copyUrl: copyBookmarkUrl,
     navigateToUrl,
     openUrl: openUrlFromNewtabCard
   });
@@ -6986,6 +6987,7 @@
     shouldSuppressHover: shouldSuppressBookmarkHover,
     bindCursorTooltip,
     hideCursorTooltip,
+    copyUrl: copyBookmarkUrl,
     showTopActionTooltip,
     hideTopActionTooltip
   });
@@ -7942,6 +7944,10 @@
     if (bookmarkPageAnimating) {
       return;
     }
+    if (event.target && typeof event.target.closest === 'function' &&
+        event.target.closest('.x-nt-bookmark-copy-action')) {
+      return;
+    }
     const card = getBookmarkCardFromNode(event.target);
     const bookmarkId = getBookmarkCardId(card);
     const parentId = getBookmarkCardParentId(card);
@@ -8593,6 +8599,63 @@
     if (toastController && typeof toastController.show === 'function') {
       toastController.show(message, { error: Boolean(isError) });
     }
+  }
+
+  function fallbackCopyText(text) {
+    if (!document || !document.body || typeof document.execCommand !== 'function') {
+      return false;
+    }
+    const activeElement = document.activeElement;
+    const textarea = document.createElement('textarea');
+    textarea.value = String(text || '');
+    textarea.setAttribute('readonly', '');
+    textarea.style.setProperty('position', 'fixed');
+    textarea.style.setProperty('left', '-9999px');
+    textarea.style.setProperty('top', '0');
+    document.body.appendChild(textarea);
+    textarea.select();
+    let copied = false;
+    try {
+      copied = document.execCommand('copy');
+    } catch (error) {
+      copied = false;
+    }
+    textarea.remove();
+    if (activeElement && typeof activeElement.focus === 'function') {
+      activeElement.focus({ preventScroll: true });
+    }
+    return copied;
+  }
+
+  function copyTextToClipboard(text) {
+    const value = String(text || '');
+    const clipboard = window.navigator && window.navigator.clipboard;
+    if (clipboard && typeof clipboard.writeText === 'function') {
+      return Promise.resolve(clipboard.writeText(value)).catch((error) => {
+        if (fallbackCopyText(value)) {
+          return true;
+        }
+        throw error;
+      });
+    }
+    return fallbackCopyText(value)
+      ? Promise.resolve(true)
+      : Promise.reject(new Error('clipboard-write-failed'));
+  }
+
+  function copyBookmarkUrl(url) {
+    const value = String(url || '').trim();
+    if (!value) {
+      showToast(t('bookmarks_copy_url_failed', 'Could not copy link'), true);
+      return Promise.resolve(false);
+    }
+    return copyTextToClipboard(value).then(() => {
+      showToast(t('bookmarks_copy_url_success', 'Bookmark link copied'));
+      return true;
+    }).catch(() => {
+      showToast(t('bookmarks_copy_url_failed', 'Could not copy link'), true);
+      return false;
+    });
   }
 
   function setSuggestionsVisible(visible) {


### PR DESCRIPTION
## 改动内容

- 为书签列表添加复制链接图标
- 图标默认隐藏，鼠标移动到书签行尾部时显示
- 长标题在图标显示时渐隐尾部文本，避免内容重叠
- 支持书签卡片和文件夹级联菜单
- 复制成功或失败时显示提示信息
- 点击复制图标不会触发书签打开或拖拽
<img width="494" height="666" alt="屏幕录制 2026-07-19 134116" src="https://github.com/user-attachments/assets/64efdc41-c578-431b-8da7-2a251bd1dbee" />


## 验证

- 通过书签复制交互测试
- 通过书签级联菜单相关回归测试
- 通过 JavaScript 和 Manifest 检查
- 通过多语言文案审计