### PR TITLE
chore: bump version to 0.9.21

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -25,7 +25,7 @@
 
 Lumno is a Manifest V3 extension for Chromium browsers. It combines a focused browser command bar with a minimal new tab page, so you can search bookmarks, history, top sites, open tabs, site-search shortcuts, and AI assistants from one place.
 
-Current version: `0.9.20`
+Current version: `0.9.21`
 
 <img width="1200" height="480" alt="Lumno command bar preview" src="./assets/images/readme/banner.webp" decoding="async" />
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@
 
 Lumno は Chromium ブラウザ向けの Manifest V3 拡張機能です。集中して使えるブラウザコマンドバーとミニマルな新しいタブを組み合わせ、ブックマーク、履歴、よく使うサイト、開いているタブ、サイト内検索、AI アシスタントをひとつの入口から探せます。
 
-現在のバージョン：`0.9.20`
+現在のバージョン：`0.9.21`
 
 <img width="1200" height="480" alt="Lumno command bar preview" src="./assets/images/readme/banner.webp" decoding="async" />
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Lumno 是一个面向 Chromium 浏览器的 Manifest V3 扩展，把「聚焦搜
   </a>
 </p>
 
-<p align="center">当前版本：<code>0.9.20</code></p>
+<p align="center">当前版本：<code>0.9.21</code></p>
 
 <img width="1200" height="480" alt="Lumno command bar preview" src="./assets/images/readme/banner.webp" decoding="async" />
 

--- a/manifest.json
+++ b/manifest.json
@@ -104,5 +104,5 @@
    "name": "__MSG_ext_name__",
    "author": "Kubai087",
    "permissions": [ "scripting", "tabs", "tabGroups", "history", "topSites", "bookmarks", "storage", "search", "favicon" ],
-   "version": "0.9.20"
+   "version": "0.9.21"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumno-extension",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "private": true,
   "scripts": {
     "test": "node scripts/run-tests.js",

--- a/scripts/test-background-search-suggestions.js
+++ b/scripts/test-background-search-suggestions.js
@@ -129,7 +129,7 @@ function createChromeStub(options) {
         return path.join(repoRoot, relativePath);
       },
       getManifest() {
-        return { version: '0.9.20' };
+        return { version: '0.9.21' };
       },
       onMessage: {
         addListener(listener) {

--- a/scripts/test-readme-store-badges.js
+++ b/scripts/test-readme-store-badges.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const path = require('path');
 
 const readme = fs.readFileSync(path.join(__dirname, '..', 'README.md'), 'utf8');
+const packageJson = require(path.join('..', 'package.json'));
+const escapedVersion = String(packageJson.version || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const badgeAssets = [
   'chrome-web-store-large-bordered.png',
   'microsoft-edge-addons-badge.png'
@@ -24,7 +26,9 @@ assert.ok(
 );
 
 assert.ok(
-  /microsoft-edge-addons-badge\.png[\s\S]*?<p align="center">当前版本：<code>0\.9\.20<\/code><\/p>/.test(readme),
+  new RegExp(
+    `microsoft-edge-addons-badge\\.png[\\s\\S]*?<p align="center">当前版本：<code>${escapedVersion}<\\/code><\\/p>`
+  ).test(readme),
   'the current version must be centered below the store badges'
 );
 


### PR DESCRIPTION
## What changed

- bump the extension, package, and README versions from `0.9.20` to `0.9.21`
- update the background search test fixture to the new manifest version
- make the README badge layout test read the current version from `package.json`

## Why

Keep release metadata synchronized after merging the bookmark copy action and prevent future version bumps from breaking a hard-coded README assertion.

## Validation

- `npm test` — all 73 test files passed
- `npm run check` — JavaScript and manifest checks passed
- `npm run audit:i18n` — locale parity and hard-coded string audit passed
