### PR TITLE
fix: increase mobile new tab spacing

### DIFF
--- a/scripts/test-newtab-layout.js
+++ b/scripts/test-newtab-layout.js
@@ -584,8 +584,8 @@ function testBottomDockCssDefinesAdaptiveDensityVariables() {
   );
   assert.match(
     newtabHtml,
-    /@media \(max-width:\s*640px\)[\s\S]*?body\.x-nt-mobile-flow\s*\{[\s\S]*?padding-top:\s*max\(32px,\s*env\(safe-area-inset-top\)\);/,
-    'mobile flow should keep a 32px minimum top inset'
+    /@media \(max-width:\s*640px\)[\s\S]*?body\.x-nt-mobile-flow\s*\{[\s\S]*?padding-top:\s*max\(48px,\s*env\(safe-area-inset-top\)\);[\s\S]*?padding-inline:\s*max\(24px,\s*env\(safe-area-inset-left\)\)\s*max\(24px,\s*env\(safe-area-inset-right\)\);/,
+    'mobile flow should keep a 48px top inset and 24px horizontal insets'
   );
   assert.match(
     newtabHtml,

--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -5528,11 +5528,11 @@
           min-height: 100vh;
           min-height: 100dvh;
           align-items: stretch;
-          padding-top: max(32px, env(safe-area-inset-top));
-          padding-right: max(16px, env(safe-area-inset-right));
+          padding-top: max(48px, env(safe-area-inset-top));
+          padding-right: max(24px, env(safe-area-inset-right));
           padding-bottom: 0;
-          padding-left: max(16px, env(safe-area-inset-left));
-          padding-inline: max(16px, env(safe-area-inset-left)) max(16px, env(safe-area-inset-right));
+          padding-left: max(24px, env(safe-area-inset-left));
+          padding-inline: max(24px, env(safe-area-inset-left)) max(24px, env(safe-area-inset-right));
           overflow-x: hidden;
           overflow-y: auto;
         }


### PR DESCRIPTION
## What changed

- increase the mobile new-tab top inset from 32px to 48px
- increase mobile horizontal insets from 16px to 24px
- update the layout regression test for the new spacing contract

## Why

This preserves the remaining local mobile-spacing fix that was not yet present on `main`.

## Validation

- `npm test` — all 73 test files passed
- `npm run check` — JavaScript and manifest checks passed
