### PR TITLE
Record and verify private media rollout

### DIFF
--- a/docs/supabase-deployment.md
+++ b/docs/supabase-deployment.md
@@ -5,9 +5,9 @@
 ## 当前云端状态
 
 - 项目：`lumno`（Ref `krpyocaoeqfwpepnsthc`），东京 `ap-northeast-1`，创建时为 Free 计划。
-- 数据库：迁移 `202608010001` 至 `202608020005` 已应用；`202608030006` 至 `202608030008` 是待部署的媒体网关与资源治理迁移。最终迁移会移除未启用的第三方审核计数，并以两个活动壁纸槽位、20 个图标、账号字节预算和全局存储停写线为准。用户/账号业务表和内部保留期表均启用并强制 RLS。
+- 数据库：迁移 `202608010001` 至 `202608030009` 已应用。媒体迁移移除了未启用的第三方审核计数，并以两个活动壁纸槽位、20 个图标、账号字节预算和全局存储停写线为准；`009` 撤销了 Auth 触发器函数不需要的公开 RPC 权限。用户/账号业务表和内部保留期表均启用并强制 RLS。
 - Storage：`lumno-user-media` 为私有 Bucket。迁移 `006` 后认证客户端没有任何直连对象策略，上传、下载和删除全部经过 `media-asset`；壁纸主图 2 MiB、缩略图 160 KiB、图标 96 KiB，账号最多两张活动壁纸、20 个图标和 10 MiB 活跃媒体。
-- Edge Functions：生产的 `telemetry-ingest`、`media-asset`、`delete-account` 均为 ACTIVE，且递归账号清理已部署；部署当前 `media-asset` 后只执行结构安全检查和资源配额，不依赖第三方审核 Secret。
+- Edge Functions：生产的 `telemetry-ingest`、`media-asset`、`delete-account` 均为 ACTIVE，且递归账号清理已部署；当前 `media-asset` 只执行结构安全检查和资源配额，不依赖第三方审核 Secret。
 - 数据保留：账号关联的每日统计与配置属性保留 24 个月，之后只汇总为不含用户、设备或配置标识的“月份 + 指标”长期总数；统计去重批次保留 30 天，同步幂等操作记录保留 90 天。
 - 客户端：`src/shared/cloud-config.js` 已填入生产 Project URL 和 Publishable Key。
 - Auth：仅开放 Google 与 GitHub；邮箱登录和新邮箱注册已关闭。Google 与 GitHub 返回同一已验证邮箱时，Supabase 会把两种身份自动关联到同一用户。
@@ -26,6 +26,7 @@
 - 两个 Edge Functions 在 Deno 2.1.4 兼容运行时成功启动。
 - 未认证访问 `telemetry-ingest` 和 `delete-account` 均返回 401。
 - `node scripts/smoke-supabase-local.js` 使用仅限测试的管理员账号夹具，实测配置推拉、私有壁纸、同意后的聚合统计和账号删除。
+- 2026-08-03：远端迁移 `006`–`008` 和当前 `media-asset` 已部署；系统目录核对确认两个壁纸槽位、10 MiB 活跃额度、日/月上传、月度下载和 900 MiB 全局停写闸门生效，第三方审核对象不存在，远端冒烟完成后一次性账号与媒体零残留。
 
 可重复本地验收：
 

--- a/scripts/helpers/media-gateway-smoke.js
+++ b/scripts/helpers/media-gateway-smoke.js
@@ -49,6 +49,29 @@ function createNormalizedIconPng() {
   ]);
 }
 
+function createStructurallyValidWebp(width, height) {
+  const chunks = [
+    ...Buffer.from('VP8X', 'ascii'),
+    10, 0, 0, 0,
+    0, 0, 0, 0,
+    (width - 1) & 0xff, ((width - 1) >>> 8) & 0xff, ((width - 1) >>> 16) & 0xff,
+    (height - 1) & 0xff, ((height - 1) >>> 8) & 0xff, ((height - 1) >>> 16) & 0xff,
+    ...Buffer.from('VP8 ', 'ascii'),
+    10, 0, 0, 0,
+    0, 0, 0, 0x9d, 0x01, 0x2a,
+    width & 0xff, (width >>> 8) & 0x3f,
+    height & 0xff, (height >>> 8) & 0x3f
+  ];
+  const bytes = Buffer.from([
+    ...Buffer.from('RIFF', 'ascii'),
+    0, 0, 0, 0,
+    ...Buffer.from('WEBP', 'ascii'),
+    ...chunks
+  ]);
+  bytes.writeUInt32LE(bytes.length - 8, 4);
+  return bytes;
+}
+
 async function parseJsonResponse(response, label) {
   const text = await response.text();
   let body = null;
@@ -101,7 +124,58 @@ async function smokeMediaGateway({ projectUrl, publishableKey, accessToken }) {
     headers: { ...commonHeaders, 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'delete', client_asset_id: clientAssetId })
   }), 'media gateway delete failed');
-  return { clientAssetId, byteSize: image.byteLength };
+
+  const wallpaperFixtures = [0, 1, 2];
+  const wallpaperIds = [];
+  const uploadWallpaper = async (fixtureIndex) => {
+    const wallpaperId = `custom-wallpaper-smoke-${crypto.randomUUID()}`;
+    const wallpaper = createStructurallyValidWebp(1920, 1080);
+    const thumbnail = createStructurallyValidWebp(480, 270);
+    const wallpaperForm = new FormData();
+    wallpaperForm.set('asset_kind', 'wallpaper');
+    wallpaperForm.set('client_asset_id', wallpaperId);
+    wallpaperForm.set('original_name', wallpaperId);
+    wallpaperForm.set('image', new Blob([wallpaper], { type: 'image/webp' }), `wallpaper-${fixtureIndex}.webp`);
+    wallpaperForm.set('thumbnail', new Blob([thumbnail], { type: 'image/webp' }), `thumbnail-${fixtureIndex}.webp`);
+    const response = await fetch(`${projectUrl}/functions/v1/media-asset`, {
+      method: 'POST',
+      headers: commonHeaders,
+      body: wallpaperForm
+    });
+    return { response, wallpaperId };
+  };
+  const deleteWallpaper = async (wallpaperId) => {
+    await parseJsonResponse(await fetch(`${projectUrl}/functions/v1/media-asset`, {
+      method: 'POST',
+      headers: { ...commonHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'delete', client_asset_id: wallpaperId })
+    }), 'wallpaper gate cleanup failed');
+  };
+
+  try {
+    for (const fixtureIndex of wallpaperFixtures.slice(0, 2)) {
+      const uploadedWallpaper = await uploadWallpaper(fixtureIndex);
+      await parseJsonResponse(uploadedWallpaper.response, 'wallpaper slot upload failed');
+      wallpaperIds.push(uploadedWallpaper.wallpaperId);
+    }
+    const thirdWallpaper = await uploadWallpaper(wallpaperFixtures[2]);
+    if (thirdWallpaper.response.ok) {
+      wallpaperIds.push(thirdWallpaper.wallpaperId);
+      throw new Error('media gateway accepted a third active wallpaper');
+    }
+    const rejectionText = await thirdWallpaper.response.text();
+    if (thirdWallpaper.response.status !== 413 || !rejectionText.includes('media_quota_exceeded')) {
+      throw new Error(
+        `unexpected third-wallpaper response: ${thirdWallpaper.response.status} ${rejectionText.slice(0, 300)}`
+      );
+    }
+  } finally {
+    for (const wallpaperId of wallpaperIds) {
+      await deleteWallpaper(wallpaperId);
+    }
+  }
+
+  return { clientAssetId, byteSize: image.byteLength, wallpaperSlotsVerified: 2 };
 }
 
 module.exports = {

--- a/scripts/test-supabase-schema.js
+++ b/scripts/test-supabase-schema.js
@@ -22,6 +22,9 @@ const retiredModerationSql = fs.readFileSync(retiredModerationMigrationPath, 'ut
 const privateMediaMigrationPath =
   'supabase/migrations/202608030008_private_active_media_sync.sql';
 const privateMediaSql = fs.readFileSync(privateMediaMigrationPath, 'utf8');
+const authTriggerHardeningMigrationPath =
+  'supabase/migrations/202608030009_revoke_auth_trigger_rpc.sql';
+const authTriggerHardeningSql = fs.readFileSync(authTriggerHardeningMigrationPath, 'utf8');
 
 function run() {
   const syncSchemaSql = `${sql}\n${syncAllowlistSql}\n${fullConfigurationSql}\n${hardeningSql}`;
@@ -150,6 +153,9 @@ function run() {
   assert.match(privateMediaSql,
     /revoke all on function public\.lumno_authorize_media_upload[\s\S]*?from public, anon, authenticated/,
     'quota functions should remain service-role-only');
+  assert.match(authTriggerHardeningSql,
+    /revoke all on function public\.lumno_handle_new_user\(\)[\s\S]*?from public, anon, authenticated/,
+    'the auth trigger function must not remain exposed as a public RPC');
 
   ['lumno_usage_monthly_totals', 'lumno_maintenance_state'].forEach((table) => {
     assert(

--- a/supabase/migrations/202608030009_revoke_auth_trigger_rpc.sql
+++ b/supabase/migrations/202608030009_revoke_auth_trigger_rpc.sql
@@ -1,0 +1,5 @@
+-- Auth creates profiles through this trigger function. It is not a public RPC
+-- and does not need EXECUTE privileges for API roles.
+
+revoke all on function public.lumno_handle_new_user()
+  from public, anon, authenticated;


### PR DESCRIPTION
## Summary
- verify the production media gateway rejects a third active wallpaper and cleans all smoke fixtures
- record the completed Supabase rollout
- revoke public RPC execution from the auth-only profile trigger function

## Verification
- remote Supabase smoke: sync, icon upload/download/delete, two wallpaper uploads, third-wallpaper rejection, telemetry, account deletion
- zero temporary-user residue
- Supabase Security Advisor confirms the auth trigger RPC warning is cleared
- remote migration dry-run is up to date
- all 130 legacy test files and npm run check pass