### PR TITLE
Fix Command shortcut tab switching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,13 @@
       },
       {
          "matches": [ "\u003Call_urls>" ],
+         "js": [ "src/content/tab-switcher-shortcut-release.js" ],
+         "run_at": "document_start",
+         "all_frames": true,
+         "match_about_blank": true
+      },
+      {
+         "matches": [ "\u003Call_urls>" ],
          "js": [ "src/shared/settings.js", "src/shared/selection-action-icons.js", "src/shared/selection-intent.js", "src/content/selection-quick-actions.js" ],
          "run_at": "document_idle"
       },

--- a/scripts/test-dev-extension-startup.js
+++ b/scripts/test-dev-extension-startup.js
@@ -32,7 +32,7 @@ async function run() {
   assert.match(backgroundSource, /DEV_EXTENSION_STARTUP\.isSameVersionReload\(details, chrome\.runtime\.getManifest\(\)\.version\)/);
   assert.match(
     backgroundSource,
-    /chrome\.runtime\.onStartup\.addListener\(\(\) => \{\s*restoreBackgroundStateOnStartup\(\);\s*\}\)/
+    /chrome\.runtime\.onStartup\.addListener\(\(\) => \{\s*prepareTabSwitcherShortcutReleaseObserversInOpenTabs\(\);\s*restoreBackgroundStateOnStartup\(\);\s*\}\)/
   );
   assert.doesNotMatch(backgroundSource, /reloadDevelopmentExtensionOnStartup/);
 }

--- a/scripts/test-recent-tab-switcher.js
+++ b/scripts/test-recent-tab-switcher.js
@@ -42,6 +42,38 @@ function testRecentStackKeepsLatestFiveSwitchableTabs() {
   );
 }
 
+function testCustomShortcutCommitModifierNormalization() {
+  assert.strictEqual(
+    switcher.getShortcutCommitModifierEventKey('Command+1'),
+    'Meta',
+    'Chrome Command shortcuts should still expose their primary modifier for held-key suppression'
+  );
+  assert.strictEqual(switcher.getShortcutCommitModifierEventKey('Ctrl+Shift+J'), 'Control');
+  assert.strictEqual(switcher.getShortcutCommitModifierEventKey('Alt+Q'), 'Alt');
+  assert.strictEqual(switcher.getShortcutCommitModifierEventKey('Shift+F2'), 'Shift');
+  assert.strictEqual(switcher.getShortcutCommitModifierEventKey('⌘1'), 'Meta');
+  assert.strictEqual(switcher.getShortcutCommitModifierEventKey('⌃⇧/'), 'Control');
+  assert.strictEqual(switcher.getShortcutCommitModifierEventKey(''), '');
+  assert.strictEqual(switcher.getShortcutTriggerEventKey('Command+1'), '1');
+  assert.strictEqual(switcher.getShortcutTriggerEventKey('Command+Shift+J'), 'j');
+  assert.strictEqual(switcher.getShortcutTriggerEventKey('Ctrl+Shift+/'), '/');
+  assert.strictEqual(switcher.getShortcutTriggerEventKey('⌘1'), '1');
+  assert.strictEqual(switcher.getShortcutTriggerEventKey('⌃⇧/'), '/');
+  assert.strictEqual(switcher.getShortcutTriggerEventKey('Shift+F2'), 'F2');
+  assert.strictEqual(switcher.getShortcutTriggerEventKey('Ctrl+Shift+Comma'), ',');
+  assert.deepStrictEqual(
+    switcher.getShortcutReleaseEventKeys('Command+1'),
+    ['Meta'],
+    'a custom Command shortcut should commit when Command is released'
+  );
+  assert.deepStrictEqual(switcher.getShortcutReleaseEventKeys('Command+Shift+J'), ['Meta']);
+  assert.deepStrictEqual(switcher.getShortcutReleaseEventKeys('⌘1'), ['Meta']);
+  assert.deepStrictEqual(switcher.getShortcutReleaseEventKeys('⌃⇧/'), ['Control']);
+  assert.deepStrictEqual(switcher.getShortcutReleaseEventKeys('Ctrl+Shift+/'), ['Control']);
+  assert.deepStrictEqual(switcher.getShortcutReleaseEventKeys('Alt+Shift+Q'), ['Alt']);
+  assert.deepStrictEqual(switcher.getShortcutReleaseEventKeys('Alt+Q'), ['Alt']);
+}
+
 function testThumbnailCacheMatchesUrlAndHydratesFromState() {
   const tracker = switcher.createRecentTabTracker({
     limit: 5,
@@ -259,6 +291,7 @@ async function testCrossWindowSwitchFocusesWindowBeforeActivatingTab() {
 
 (async () => {
   testRecentStackKeepsLatestFiveSwitchableTabs();
+  testCustomShortcutCommitModifierNormalization();
   testThumbnailCacheMatchesUrlAndHydratesFromState();
   testRecordingSameTabKeepsMatchingThumbnail();
   testThumbnailStatusPersistsAndReportsStaleness();

--- a/scripts/test-tab-switcher-extension-page-runtime.js
+++ b/scripts/test-tab-switcher-extension-page-runtime.js
@@ -16,21 +16,23 @@ const { window } = dom;
 let createViewCalls = 0;
 let latestViewOptions = null;
 const runtimeMessages = [];
+let runtimeMessageListener = null;
+let cardClickEvents = 0;
 const keyupListeners = new Set();
-const addWindowEventListener = window.addEventListener.bind(window);
-const removeWindowEventListener = window.removeEventListener.bind(window);
+const nativeAddEventListener = window.addEventListener.bind(window);
+const nativeRemoveEventListener = window.removeEventListener.bind(window);
 
 window.addEventListener = (type, listener, options) => {
   if (type === 'keyup') {
     keyupListeners.add(listener);
   }
-  return addWindowEventListener(type, listener, options);
+  return nativeAddEventListener(type, listener, options);
 };
 window.removeEventListener = (type, listener, options) => {
   if (type === 'keyup') {
     keyupListeners.delete(listener);
   }
-  return removeWindowEventListener(type, listener, options);
+  return nativeRemoveEventListener(type, listener, options);
 };
 
 window.matchMedia = () => ({
@@ -50,6 +52,16 @@ window.chrome = {
     }
   },
   runtime: {
+    onMessage: {
+      addListener(listener) {
+        runtimeMessageListener = listener;
+      },
+      removeListener(listener) {
+        if (runtimeMessageListener === listener) {
+          runtimeMessageListener = null;
+        }
+      }
+    },
     sendMessage(message, callback) {
       runtimeMessages.push(message);
       callback?.();
@@ -91,16 +103,20 @@ window.LumnoOverlayTabSwitcherView = {
     latestViewOptions = options;
     const panel = window.document.createElement('div');
     panel.id = options.panelId;
-    const button = window.document.createElement('button');
-    button.className = 'x-tab-switcher-card';
-    button.addEventListener('click', (event) => {
-      options.onActivate(0, event);
+    const buttons = options.tabs.map((_tab, index) => {
+      const button = window.document.createElement('button');
+      button.className = 'x-tab-switcher-card';
+      button.addEventListener('click', (event) => {
+        cardClickEvents += 1;
+        options.onActivate(index, event);
+      });
+      panel.appendChild(button);
+      return button;
     });
-    panel.appendChild(button);
     options.root.appendChild(panel);
     return {
       panel,
-      buttons: [button],
+      buttons,
       destroy() {},
       updateSelection() {},
       updateThumbnail() {
@@ -112,7 +128,12 @@ window.LumnoOverlayTabSwitcherView = {
 
 const readyResult =
   window._x_extension_toggleTabSwitcher_2026_unique_({
-    tabs: [{ id: 1, title: 'After React' }]
+    tabs: [
+      { id: 1, title: 'After React' },
+      { id: 2, title: 'Custom shortcut target' }
+    ],
+    shortcut: 'Command+1',
+    suppressInitialShortcutAdvance: true
   });
 assert.deepStrictEqual(
   { ...readyResult },
@@ -156,6 +177,91 @@ assert.ok(
   'rejected synthetic events must leave the switcher available for real input'
 );
 
+switcherHost._lumnoTabSwitcherAdvance(1);
+const clickEventsBeforeRelease = cardClickEvents;
+const shortcutKeyupListener = Array.from(keyupListeners).at(-1);
+assert.strictEqual(typeof shortcutKeyupListener, 'function');
+const trustedShortcutKeyupEvent = (key, code) => ({
+  isTrusted: true,
+  key,
+  code,
+  preventDefault() {},
+  stopImmediatePropagation() {},
+  stopPropagation() {}
+});
+shortcutKeyupListener(trustedShortcutKeyupEvent('1', 'Digit1'));
+assert.strictEqual(
+  cardClickEvents,
+  clickEventsBeforeRelease,
+  'releasing the custom trigger key must not commit while Command is still the hold modifier'
+);
+assert.ok(
+  switcherHost.isConnected,
+  'the switcher should remain open until the primary modifier is released'
+);
+shortcutKeyupListener(trustedShortcutKeyupEvent('Meta', 'MetaLeft'));
+assert.strictEqual(
+  cardClickEvents,
+  clickEventsBeforeRelease + 1,
+  'releasing Command should dispatch exactly one guarded click on the highlighted card'
+);
+assert.deepStrictEqual(
+  runtimeMessages.map((message) => ({ ...message })),
+  [{ action: 'switchToTab', tabId: 2, windowId: null }],
+  'releasing Command should activate the highlighted tab'
+);
+assert.strictEqual(
+  switcherHost.isConnected,
+  false,
+  'the switcher should close after Command release commits the selection'
+);
+
+runtimeMessages.length = 0;
+window._x_extension_toggleTabSwitcher_2026_unique_({
+  tabs: [
+    { id: 1, title: 'Relay source' },
+    { id: 2, title: 'Relay target' }
+  ],
+  shortcut: 'Command+1'
+});
+const relayedSwitcherHost = window.document.getElementById(
+  '_x_extension_tab_switcher_host_2026_unique_'
+);
+relayedSwitcherHost._lumnoTabSwitcherAdvance(1);
+const clickEventsBeforeRelayedRelease = cardClickEvents;
+let releaseCommitResponse = null;
+runtimeMessageListener({
+  action: 'commitOpenTabSwitcherFromShortcutRelease'
+}, {}, (response) => {
+  releaseCommitResponse = response;
+});
+assert.deepStrictEqual(
+  { ...releaseCommitResponse },
+  { ok: true, committed: true },
+  'a relayed Command release must commit an open switcher even when the original keyup reached another tab'
+);
+assert.strictEqual(
+  cardClickEvents,
+  clickEventsBeforeRelayedRelease + 1,
+  'the relayed release should dispatch exactly one guarded click on the highlighted card'
+);
+assert.deepStrictEqual(
+  runtimeMessages.map((message) => ({ ...message })),
+  [{ action: 'switchToTab', tabId: 2, windowId: null }],
+  'the relayed Command release must activate the highlighted tab'
+);
+assert.strictEqual(
+  relayedSwitcherHost.isConnected,
+  false,
+  'a committed custom shortcut selection should close the switcher'
+);
+
+runtimeMessages.length = 0;
+window._x_extension_toggleTabSwitcher_2026_unique_({
+  tabs: [{ id: 1, title: 'Trusted pointer target' }],
+  shortcut: 'Alt+Q'
+});
+
 latestViewOptions.onActivate(0, {
   isTrusted: true,
   preventDefault() {},
@@ -166,42 +272,6 @@ assert.deepStrictEqual(
   runtimeMessages.map((message) => ({ ...message })),
   [{ action: 'switchToTab', tabId: 1, windowId: null }],
   'a trusted activation must preserve the normal privileged switch path'
-);
-
-const commandShortcutResult =
-  window._x_extension_toggleTabSwitcher_2026_unique_({
-    tabs: [{ id: 2, title: 'Command shortcut' }],
-    suppressInitialShortcutAdvance: true
-  });
-assert.deepStrictEqual(
-  { ...commandShortcutResult },
-  { ok: true },
-  'the switcher should reopen for a Command shortcut'
-);
-const commandShortcutHost = window.document.getElementById(
-  '_x_extension_tab_switcher_host_2026_unique_'
-);
-const commandKeyupListener = Array.from(keyupListeners).at(-1);
-assert.strictEqual(typeof commandKeyupListener, 'function');
-commandKeyupListener({
-  isTrusted: true,
-  key: 'Meta',
-  preventDefault() {},
-  stopImmediatePropagation() {},
-  stopPropagation() {}
-});
-assert.deepStrictEqual(
-  runtimeMessages.map((message) => ({ ...message })),
-  [
-    { action: 'switchToTab', tabId: 1, windowId: null },
-    { action: 'switchToTab', tabId: 2, windowId: null }
-  ],
-  'releasing Command should activate the selected tab for a Command-based shortcut'
-);
-assert.strictEqual(
-  commandShortcutHost.isConnected,
-  false,
-  'the switcher should close after the Command shortcut commits the selection'
 );
 
 dom.window.close();

--- a/scripts/test-tab-switcher-extension-page-runtime.js
+++ b/scripts/test-tab-switcher-extension-page-runtime.js
@@ -16,6 +16,22 @@ const { window } = dom;
 let createViewCalls = 0;
 let latestViewOptions = null;
 const runtimeMessages = [];
+const keyupListeners = new Set();
+const addWindowEventListener = window.addEventListener.bind(window);
+const removeWindowEventListener = window.removeEventListener.bind(window);
+
+window.addEventListener = (type, listener, options) => {
+  if (type === 'keyup') {
+    keyupListeners.add(listener);
+  }
+  return addWindowEventListener(type, listener, options);
+};
+window.removeEventListener = (type, listener, options) => {
+  if (type === 'keyup') {
+    keyupListeners.delete(listener);
+  }
+  return removeWindowEventListener(type, listener, options);
+};
 
 window.matchMedia = () => ({
   matches: false,
@@ -150,6 +166,42 @@ assert.deepStrictEqual(
   runtimeMessages.map((message) => ({ ...message })),
   [{ action: 'switchToTab', tabId: 1, windowId: null }],
   'a trusted activation must preserve the normal privileged switch path'
+);
+
+const commandShortcutResult =
+  window._x_extension_toggleTabSwitcher_2026_unique_({
+    tabs: [{ id: 2, title: 'Command shortcut' }],
+    suppressInitialShortcutAdvance: true
+  });
+assert.deepStrictEqual(
+  { ...commandShortcutResult },
+  { ok: true },
+  'the switcher should reopen for a Command shortcut'
+);
+const commandShortcutHost = window.document.getElementById(
+  '_x_extension_tab_switcher_host_2026_unique_'
+);
+const commandKeyupListener = Array.from(keyupListeners).at(-1);
+assert.strictEqual(typeof commandKeyupListener, 'function');
+commandKeyupListener({
+  isTrusted: true,
+  key: 'Meta',
+  preventDefault() {},
+  stopImmediatePropagation() {},
+  stopPropagation() {}
+});
+assert.deepStrictEqual(
+  runtimeMessages.map((message) => ({ ...message })),
+  [
+    { action: 'switchToTab', tabId: 1, windowId: null },
+    { action: 'switchToTab', tabId: 2, windowId: null }
+  ],
+  'releasing Command should activate the selected tab for a Command-based shortcut'
+);
+assert.strictEqual(
+  commandShortcutHost.isConnected,
+  false,
+  'the switcher should close after the Command shortcut commits the selection'
 );
 
 dom.window.close();

--- a/scripts/test-tab-switcher-hotkeys.js
+++ b/scripts/test-tab-switcher-hotkeys.js
@@ -411,8 +411,8 @@ assert.match(
 );
 assert.match(
   switcherSource,
-  /function handleKeyup[\s\S]*event\.key === 'Alt'[\s\S]*switchToSelected\(\)/,
-  'tab switcher should switch to the selected tab when Alt is released'
+  /function handleKeyup[\s\S]*event\.key === 'Alt' \|\| event\.key === 'Meta'[\s\S]*switchToSelected\(\)/,
+  'tab switcher should switch to the selected tab when Alt or Command is released'
 );
 assert.match(
   switcherSource,

--- a/scripts/test-tab-switcher-hotkeys.js
+++ b/scripts/test-tab-switcher-hotkeys.js
@@ -2,6 +2,10 @@ const assert = require('assert');
 const fs = require('fs');
 
 const contentHotkeySource = fs.readFileSync('src/content/hotkey-listener.js', 'utf8');
+const shortcutReleaseRelaySource = fs.readFileSync(
+  'src/content/tab-switcher-shortcut-release.js',
+  'utf8'
+);
 const backgroundSource = fs.readFileSync('src/background/background.js', 'utf8');
 const switcherSource = fs.readFileSync('src/overlay/tab-switcher.js', 'utf8');
 const switcherViewReactSource = fs.readFileSync(
@@ -92,6 +96,11 @@ assert.match(
 );
 assert.match(
   switcherSource,
+  /function commitOpenSwitcherFromShortcutReleaseMessage\(\)[\s\S]*_lumnoTabSwitcherCommitFromShortcutRelease\(\)[\s\S]*request\.action === 'commitOpenTabSwitcherFromShortcutRelease'/,
+  'normal-page switchers should accept the configured release relayed from the tab that received the original key sequence'
+);
+assert.match(
+  switcherSource,
   /previousRuntimeMessageListener[\s\S]*removeListener\(previousRuntimeMessageListener\)[\s\S]*addListener\(runtimeMessageListener\)/,
   'reinjection should replace an invalidated runtime listener after an extension reload'
 );
@@ -134,6 +143,43 @@ assert.match(
   switcherBridgeSource,
   /respondToExtensionPageRequest[\s\S]*advanced:[\s\S]*open:[\s\S]*suppressed:/,
   'shared tab switcher bridge should pass command advance and open-state status back to extension-page ports'
+);
+assert.match(
+  switcherBridgeSource,
+  /function commitOpenTabSwitcherFromShortcutRelease\(\)[\s\S]*_lumnoTabSwitcherCommitFromShortcutRelease\(\)[\s\S]*request\.action === 'commitOpenTabSwitcherFromShortcutRelease'/,
+  'extension-page switchers should accept the same relayed configured-key release command'
+);
+assert.match(
+  shortcutReleaseRelaySource,
+  /RUNTIME_KEY[\s\S]*previousRuntime\.cleanup\(\)[\s\S]*RELEASE_REPLAY_WINDOW_MS[\s\S]*function rememberTrustedShortcutRelease\(event\)[\s\S]*function getBufferedReleasedShortcutKey\(keys, commandStartedAt\)[\s\S]*observedAt >= startedAt[\s\S]*request\.commandStartedAt[\s\S]*function notifyTabSwitcherShortcutModifierReleased\(event\)[\s\S]*event\.isTrusted !== true[\s\S]*rememberTrustedShortcutRelease\(event\)[\s\S]*relayTabSwitcherShortcutRelease\(key\)[\s\S]*window\.addEventListener\('keyup',\s*notifyTabSwitcherShortcutModifierReleased,\s*true\)[\s\S]*removeEventListener\('keyup',\s*notifyTabSwitcherShortcutModifierReleased/,
+  'the document-start observer should relay live releases and replay only trusted releases from the current shortcut command'
+);
+assert.match(
+  backgroundSource,
+  /function prepareTabSwitcherShortcutReleaseObserver\(tab\)[\s\S]*allFrames:\s*true[\s\S]*files:\s*\['src\/content\/tab-switcher-shortcut-release\.js'\]/,
+  'the background should dynamically install the release observer in already-open tabs and focused frames'
+);
+assert.match(
+  backgroundSource,
+  /function prepareTabSwitcherShortcutReleaseObserversInOpenTabs\(\)[\s\S]*chrome\.tabs\.query\(\{\},[\s\S]*prepareTabSwitcherShortcutReleaseObserver\(tab\)[\s\S]*chrome\.runtime\.onInstalled\.addListener\([\s\S]*prepareTabSwitcherShortcutReleaseObserversInOpenTabs\(\)[\s\S]*chrome\.runtime\.onStartup\.addListener\([\s\S]*prepareTabSwitcherShortcutReleaseObserversInOpenTabs\(\)/,
+  'extension reload and browser startup should prepare already-open tabs before the user presses the shortcut'
+);
+const shortcutReleaseContentScript = manifest.content_scripts.find((entry) => (
+  entry &&
+  Array.isArray(entry.js) &&
+  entry.js.includes('src/content/tab-switcher-shortcut-release.js')
+));
+assert.ok(
+  shortcutReleaseContentScript &&
+    shortcutReleaseContentScript.run_at === 'document_start' &&
+    shortcutReleaseContentScript.all_frames === true &&
+    shortcutReleaseContentScript.match_about_blank === true,
+  'the release observer should be present before the command in every focused frame, including inherited about:blank editors'
+);
+assert.match(
+  switcherBridgeSource,
+  /TAB_SWITCHER_RELEASE_REPLAY_WINDOW_MS[\s\S]*function rememberTrustedTabSwitcherShortcutRelease\(event\)[\s\S]*function getBufferedTabSwitcherShortcutReleaseKey\(keys, commandStartedAt\)[\s\S]*observedAt >= startedAt[\s\S]*request\.commandStartedAt[\s\S]*function notifyTabSwitcherShortcutModifierReleased\(event\)[\s\S]*event\.isTrusted !== true[\s\S]*rememberTrustedTabSwitcherShortcutRelease\(event\)[\s\S]*relayTabSwitcherShortcutRelease\(key\)[\s\S]*window\.addEventListener\('keyup',\s*notifyTabSwitcherShortcutModifierReleased,\s*true\)/,
+  'extension pages should preserve the same current-command release replay behavior through their persistent bridge'
 );
 assert.match(
   switcherBridgeSource,
@@ -371,18 +417,18 @@ assert.strictEqual(
 );
 assert.match(
   switcherSource,
-  /keyText === 'q'[\s\S]*selectByOffset\(1\)/,
-  'tab switcher should allow Q to cycle to the next item'
+  /isTabSwitcherShortcutTriggerEvent\(shortcut,\s*event\)[\s\S]*selectByOffset\(1\)/,
+  'tab switcher should allow the configured shortcut key to cycle to the next item'
 );
 assert.match(
   switcherSource,
-  /let suppressInitialShortcutAdvanceUntilQKeyup = context\.suppressInitialShortcutAdvance === true;/,
-  'tab switcher should suppress only the initial held Q until the first Q keyup'
+  /let suppressInitialShortcutAdvanceUntilTriggerKeyup = context\.suppressInitialShortcutAdvance === true;/,
+  'tab switcher should suppress only the initial held shortcut key until its first keyup'
 );
 assert.match(
   switcherSource,
-  /function shouldSuppressInitialShortcutAdvance\(\)[\s\S]*return suppressInitialShortcutAdvanceUntilQKeyup;/,
-  'tab switcher should use key state, not a time window, for initial held-Q suppression'
+  /function shouldSuppressInitialShortcutAdvance\(\)[\s\S]*return suppressInitialShortcutAdvanceUntilTriggerKeyup;/,
+  'tab switcher should use key state, not a time window, for initial held-shortcut suppression'
 );
 assert.strictEqual(
   /INITIAL_SHORTCUT_ADVANCE_SUPPRESS_MS|Date\.now\(\)\s*\+/.test(switcherSource),
@@ -391,33 +437,38 @@ assert.strictEqual(
 );
 assert.match(
   switcherSource,
-  /function advanceSelectionFromShortcut\(offset\)[\s\S]*suppressInitialShortcutAdvanceUntilQKeyup = false;[\s\S]*selectByOffset\(offset\);[\s\S]*return true;/,
+  /function advanceSelectionFromShortcut\(offset\)[\s\S]*suppressInitialShortcutAdvanceUntilTriggerKeyup = false;[\s\S]*selectByOffset\(offset\);[\s\S]*return true;/,
   'tab switcher command re-entry should clear initial suppression and advance while Alt remains held'
 );
 assert.match(
   switcherSource,
-  /if \(keyText === 'q'\)[\s\S]*if \(shouldSuppressInitialShortcutAdvance\(\) && event\.altKey\)[\s\S]*return;[\s\S]*selectByOffset\(1\)/,
-  'tab switcher should ignore immediate held Alt+Q duplicate keydowns without preventing later Q cycling'
+  /if \(isTabSwitcherShortcutTriggerEvent\(shortcut,\s*event\)\)[\s\S]*if \(shouldSuppressInitialShortcutAdvance\(\) && isTabSwitcherCommitModifierPressed\(shortcut,\s*event\)\)[\s\S]*return;[\s\S]*selectByOffset\(1\)/,
+  'tab switcher should ignore immediate held shortcut duplicate keydowns without preventing later cycling'
 );
 assert.match(
   switcherSource,
-  /if \(keyText === 'q'\)[\s\S]*if \(shouldSuppressInitialShortcutAdvance\(\) && event\.altKey\)[\s\S]*return;[\s\S]*suppressInitialShortcutAdvanceUntilQKeyup = false;[\s\S]*selectByOffset\(1\)/,
-  'tab switcher should clear initial suppression when Q is pressed after Alt has been released'
+  /if \(isTabSwitcherShortcutTriggerEvent\(shortcut,\s*event\)\)[\s\S]*if \(shouldSuppressInitialShortcutAdvance\(\) && isTabSwitcherCommitModifierPressed\(shortcut,\s*event\)\)[\s\S]*return;[\s\S]*suppressInitialShortcutAdvanceUntilTriggerKeyup = false;[\s\S]*selectByOffset\(1\)/,
+  'tab switcher should clear initial suppression when the shortcut key is pressed after its modifier has been released'
 );
 assert.match(
   switcherSource,
-  /function handleKeyup[\s\S]*keyText === 'q'[\s\S]*suppressInitialShortcutAdvanceUntilQKeyup = false;[\s\S]*stopHandledKeyEvent\(event\);[\s\S]*if \(!event\.altKey\)[\s\S]*switchToSelected\(\)/,
-  'tab switcher should clear the initial Q suppression on Q release without committing while Alt is still held'
+  /function handleKeyup[\s\S]*isTabSwitcherShortcutTriggerEvent\(shortcut,\s*event\)[\s\S]*suppressInitialShortcutAdvanceUntilTriggerKeyup = false;[\s\S]*stopHandledKeyEvent\(event\);[\s\S]*return;/,
+  'releasing a custom shortcut trigger should clear suppression without committing while its modifier remains held'
 );
 assert.match(
   switcherSource,
-  /function handleKeyup[\s\S]*event\.key === 'Alt' \|\| event\.key === 'Meta'[\s\S]*switchToSelected\(\)/,
-  'tab switcher should switch to the selected tab when Alt or Command is released'
+  /function handleKeyup[\s\S]*shortcut\.commitModifierEventKey[\s\S]*event\.key === shortcut\.commitModifierEventKey[\s\S]*clickSelectedCardFromShortcutRelease\(\)/,
+  'default and custom shortcuts should commit when their configured primary modifier is released'
 );
 assert.match(
   switcherSource,
   /window\.addEventListener\('keyup',\s*handleKeyup,\s*true\)/,
   'tab switcher should listen for keyup so command-key release can commit the selection'
+);
+assert.strictEqual(
+  /focusSelectedCardForShortcutRelease|focusedElementBeforeOpen|restoreFocusAfterClose/.test(switcherSource),
+  false,
+  'shortcut release recovery should not steal or rewrite the page focus chain'
 );
 assert.match(
   switcherSource,
@@ -1492,13 +1543,137 @@ const triggerSwitcherBlock = getFunctionBlock(
 );
 assert.match(
   triggerSwitcherBlock,
-  /if \(didAdvance\)[\s\S]*return;[\s\S]*const opening = beginTabSwitcherOpening\(tab,\s*source\);[\s\S]*if \(!opening\)[\s\S]*return;[\s\S]*const finishOpening = createTabSwitcherOpeningFinisher\(opening\);[\s\S]*ensureTabSwitcherStateLoaded/,
+  /if \(didAdvance\)[\s\S]*return;[\s\S]*const opening = beginTabSwitcherOpening\(tab,\s*source\);[\s\S]*if \(!opening\)[\s\S]*return;[\s\S]*const finishOpeningGuard = createTabSwitcherOpeningFinisher\(opening\);[\s\S]*const finishOpening = \(ok\) =>[\s\S]*ensureTabSwitcherStateLoaded/,
   'Alt+Q fast cycling should return before opening guard setup, then guard the async payload build before waiting on thumbnail state loading'
 );
 assert.match(
   triggerSwitcherBlock,
-  /const startupStateReady = Promise\.all\(\[\s*ensureTabSwitcherStateLoaded\(\),\s*loadFaviconRequestBlacklistItems\(\),\s*loadFaviconEnhancedFetchEnabled\(\)\s*\]\)[\s\S]*const tabQueryReady = new Promise[\s\S]*Promise\.all\(\[startupStateReady,\s*tabQueryReady\]\)[\s\S]*getRecentTabsForSwitcher/,
-  'Alt+Q should query tabs in parallel with local state and favicon policy loading'
+  /const releaseObserverReady = prepareTabSwitcherShortcutReleaseObserver\(tab\);[\s\S]*advanceExistingTabSwitcherOnTab\(tab,[\s\S]*Promise\.all\(\[startupStateReady,\s*tabQueryReady,\s*shortcutReady,\s*releaseObserverReady\]\)/,
+  'the trusted release observer should start before asynchronous switcher opening work so quick releases can be buffered'
+);
+assert.match(
+  triggerSwitcherBlock,
+  /const startupStateReady = Promise\.all\(\[\s*ensureTabSwitcherStateLoaded\(\),\s*loadFaviconRequestBlacklistItems\(\),\s*loadFaviconEnhancedFetchEnabled\(\)\s*\]\)[\s\S]*const shortcutReady = new Promise[\s\S]*getConfiguredTabSwitcherShortcut\(resolve\)[\s\S]*const tabQueryReady = new Promise[\s\S]*Promise\.all\(\[startupStateReady,\s*tabQueryReady,\s*shortcutReady,\s*releaseObserverReady\]\)[\s\S]*getRecentTabsForSwitcher/,
+  'the tab switcher should resolve tabs, local state, favicon policy, and the configured shortcut in parallel'
+);
+assert.match(
+  backgroundSource,
+  /function getConfiguredTabSwitcherShortcut\(callback\)[\s\S]*chrome\.commands\.getAll\([\s\S]*SHOW_TAB_SWITCHER_COMMAND_NAME[\s\S]*callback\(shortcut \|\| fallbackShortcut\)/,
+  'the background should read the current browser-configured tab switcher shortcut with an Alt+Q fallback'
+);
+const shortcutReleaseHandlerBlock = getFunctionBlock(
+  backgroundSource,
+  'function handleTabSwitcherShortcutModifierReleased(senderTab, releasedKey, callback)',
+  'function waitForTabSwitcherCapturePaint()'
+);
+assert.match(
+  shortcutReleaseHandlerBlock,
+  /getConfiguredTabSwitcherShortcut[\s\S]*getShortcutReleaseEventKeys\(shortcut\)[\s\S]*expectedKeys\.includes\(key\)[\s\S]*commitOpenTabSwitcherInWindow\(senderTab\.windowId, 'keyup'\)/,
+  'the background should validate the configured release key, then locate the real open switcher in the sender window'
+);
+assert.match(
+  backgroundSource,
+  /function armTabSwitcherShortcutReleaseObservers\(tabs, windowId, shortcut, commandStartedAt\)[\s\S]*getShortcutReleaseEventKeys\(shortcut\)[\s\S]*action:\s*'armTabSwitcherShortcutRelease'[\s\S]*commandStartedAt:\s*Number\(commandStartedAt\)[\s\S]*postTabSwitcherMessageToExtensionPage[\s\S]*chrome\.tabs\.sendMessage/,
+  'every eligible release observer should receive the timestamp needed to recover a fast keyup'
+);
+assert.match(
+  triggerSwitcherBlock,
+  /const commandStartedAt = Date\.now\(\)[\s\S]*const finishOpeningAndArmShortcutRelease = \(ok\) => \{\s*finishOpening\(ok\);\s*if \(ok === true\) \{\s*armTabSwitcherShortcutReleaseObservers\([\s\S]*commandStartedAt[\s\S]*onOpenComplete:\s*finishOpeningAndArmShortcutRelease/,
+  'release replay should be armed only after the switcher host is mounted and ready to commit'
+);
+assert.match(
+  switcherSource,
+  /function clickSelectedCardFromShortcutRelease\(\)[\s\S]*allowRelayedShortcutReleaseActivation = true;[\s\S]*selectedButton\.click\(\)[\s\S]*host\._lumnoTabSwitcherCommitFromShortcutRelease = function\(\)[\s\S]*clickSelectedCardFromShortcutRelease\(\)/,
+  'custom shortcut modifier release should use a narrowly authorized click on the highlighted card'
+);
+[
+  'createShortcutInactivityCommitController',
+  'tabSwitcherShortcutInactivityCommitController',
+  'TAB_SWITCHER_CUSTOM_INITIAL_INACTIVITY_COMMIT_MS',
+  'TAB_SWITCHER_CUSTOM_REPEAT_INACTIVITY_COMMIT_MS',
+  'commitOpenTabSwitcherAfterCommandInactivity',
+  'inactivity-fired',
+  'usesInactivityFallback'
+].forEach((needle) => {
+  assert.strictEqual(
+    backgroundSource.includes(needle),
+    false,
+    `holding a custom shortcut must not retain the automatic ${needle} path`
+  );
+});
+assert.match(
+  triggerSwitcherBlock,
+  /const windowId = typeof tab\.windowId[\s\S]*if \(didAdvance\)[\s\S]*tabSwitcherHostTabIdByWindowId\.set\(tab\.windowId, tab\.id\)[\s\S]*recordTabSwitcherShortcutDebug\('command-advanced',[\s\S]*const finishOpening = \(ok\)[\s\S]*tabSwitcherHostTabIdByWindowId\.set\(windowId, openingHostTabId\)[\s\S]*shortcut-configured[\s\S]*releaseKeys[\s\S]*onOpenComplete:\s*finishOpening/,
+  'initial and repeated commands should remember the host and wait for the configured release key'
+);
+assert.match(
+  backgroundSource,
+  /function findOpenTabSwitcherHostInWindow\(windowId\)[\s\S]*TAB_SWITCHER_HOST_STATE_TIMEOUT_MS[\s\S]*getOpenTabSwitcherState\(tab\)[\s\S]*chrome\.tabs\.query\(\{ windowId \}[\s\S]*state\.open === true[\s\S]*function commitOpenTabSwitcherInWindow\(windowId, source\)[\s\S]*commitOpenTabSwitcherFromShortcutReleaseOnTab\(hostTab\)[\s\S]*commitOpenTabSwitcherInWindow\(senderTab\.windowId, 'keyup'\)/,
+  'a real release should locate the actual open host before using the guarded click commit route'
+);
+assert.match(
+  backgroundSource,
+  /tabSwitcherHostTabIdByWindowId = new Map\(\)[\s\S]*tabSwitcherHostTabIdByWindowId\.set\(windowId, openingHostTabId\)/,
+  'the switcher should remember the real host tab when opening completes'
+);
+assert.match(
+  backgroundSource,
+  /function commitOpenTabSwitcherInWindow\(windowId, source\)[\s\S]*knownHostTabId = tabSwitcherHostTabIdByWindowId\.get\(windowId\)[\s\S]*getTabForTabSwitcherCommit\(knownHostTabId\)[\s\S]*finishCommit\(hostTab, 'known-host'\)/,
+  'the normal commit path should use the remembered host instead of waiting on every tab'
+);
+assert.match(
+  backgroundSource,
+  /function normalizeTabSwitcherCommitResponse\(response\)[\s\S]*response\.ok !== true[\s\S]*typeof response\.committed !== 'boolean'[\s\S]*response\.committed === true/,
+  'the background should preserve the real committed message result instead of treating host reachability as a successful switch'
+);
+assert.match(
+  backgroundSource,
+  /function normalizeTabSwitcherCommitScriptResults\(results\)[\s\S]*typeof item\.result\.committed === 'boolean'[\s\S]*result\.result\.committed === true/,
+  'the script fallback should preserve the real committed result'
+);
+assert.match(
+  backgroundSource,
+  /function commitOpenTabSwitcherFromShortcutReleaseOnTab\(tab\)[\s\S]*normalizeResponse:\s*normalizeTabSwitcherCommitResponse[\s\S]*normalizeScriptResults:\s*normalizeTabSwitcherCommitScriptResults/,
+  'the guarded click route should use committed-aware response normalization for messages and script fallback'
+);
+assert.match(
+  shortcutReleaseHandlerBlock,
+  /commitOpenTabSwitcherInWindow\(senderTab\.windowId, 'keyup'\)[\s\S]*\.then\(\(didCommit\) => finish\(didCommit === true\)\)/,
+  'a validated real release should be the only path that commits the highlighted tab'
+);
+assert.match(
+  backgroundSource,
+  /globalThis\._lumnoTabSwitcherShortcutDebug = Object\.freeze\(\{[\s\S]*snapshot\(\)[\s\S]*clear\(\)/,
+  'the service worker should expose a bounded shortcut diagnostic trace'
+);
+[
+  'shortcut-configured',
+  'switcher-opened',
+  'commit-host-resolved',
+  'commit-finished'
+].forEach((stage) => {
+  assert.ok(
+    backgroundSource.includes(`recordTabSwitcherShortcutDebug('${stage}'`),
+    `the shortcut diagnostic trace should record ${stage}`
+  );
+});
+assert.deepStrictEqual(
+  [...backgroundSource.matchAll(/commitOpenTabSwitcherInWindow\([^\n]+/g)].map((match) => match[0]),
+  [
+    'commitOpenTabSwitcherInWindow(windowId, source) {',
+    "commitOpenTabSwitcherInWindow(senderTab.windowId, 'keyup')"
+  ],
+  'the open switcher should only be committed by a real keyup notification'
+);
+assert.match(
+  backgroundSource,
+  /shortcuts:\s*\{[\s\S]*'notifyTabSwitcherShortcutModifierReleased'[\s\S]*handler:\s*handleShortcutMessage[\s\S]*case 'notifyTabSwitcherShortcutModifierReleased':[\s\S]*handleTabSwitcherShortcutModifierReleased/,
+  'the trusted frame release notification should be routed into the tab switcher commit path'
+);
+assert.match(
+  injectSwitcherBlock,
+  /shortcut:\s*context && typeof context\.shortcut === 'string' \? context\.shortcut : 'Alt\+Q'/,
+  'the switcher open context should carry the browser-configured shortcut into the page runtime'
 );
 assert.match(
   triggerSwitcherBlock,

--- a/scripts/test-tab-switcher-shortcut-release-relay.js
+++ b/scripts/test-tab-switcher-shortcut-release-relay.js
@@ -1,0 +1,152 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const repoRoot = path.join(__dirname, '..');
+const source = fs.readFileSync(
+  path.join(repoRoot, 'src', 'content', 'tab-switcher-shortcut-release.js'),
+  'utf8'
+);
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  runScripts: 'outside-only',
+  url: 'https://editor.example.test/frame'
+});
+const { window } = dom;
+const runtimeMessages = [];
+let keyupHandler = null;
+let runtimeMessageListener = null;
+const keyupHandlers = new Set();
+const runtimeMessageListeners = new Set();
+const nativeAddEventListener = window.addEventListener.bind(window);
+const nativeRemoveEventListener = window.removeEventListener.bind(window);
+
+window.addEventListener = (type, listener, options) => {
+  if (type === 'keyup') {
+    keyupHandler = listener;
+    keyupHandlers.add(listener);
+  }
+  return nativeAddEventListener(type, listener, options);
+};
+window.removeEventListener = (type, listener, options) => {
+  if (type === 'keyup') {
+    keyupHandlers.delete(listener);
+  }
+  return nativeRemoveEventListener(type, listener, options);
+};
+window.chrome = {
+  runtime: {
+    lastError: null,
+    onMessage: {
+      addListener(listener) {
+        runtimeMessageListener = listener;
+        runtimeMessageListeners.add(listener);
+      },
+      removeListener(listener) {
+        runtimeMessageListeners.delete(listener);
+      }
+    },
+    sendMessage(message, callback) {
+      runtimeMessages.push(message);
+      callback?.();
+    }
+  }
+};
+
+window.eval(source);
+assert.strictEqual(typeof keyupHandler, 'function', 'the frame should observe configured shortcut-key releases');
+assert.strictEqual(typeof runtimeMessageListener, 'function', 'the frame should wait for the switcher command to arm it');
+window.eval(source);
+assert.strictEqual(
+  keyupHandlers.size,
+  1,
+  'reinjection after an extension reload should replace the stale keyup listener'
+);
+assert.strictEqual(
+  runtimeMessageListeners.size,
+  1,
+  'reinjection after an extension reload should replace the stale runtime listener'
+);
+
+keyupHandler({ isTrusted: false, key: 'Meta', code: 'MetaLeft' });
+keyupHandler({ isTrusted: true, key: '1', code: 'Digit1' });
+assert.deepStrictEqual(
+  runtimeMessages,
+  [],
+  'synthetic and unarmed releases must not cross the privileged runtime boundary'
+);
+
+let armResponse = null;
+runtimeMessageListener({ action: 'armTabSwitcherShortcutRelease', keys: ['Meta'] }, {}, (response) => {
+  armResponse = response;
+});
+assert.deepStrictEqual({ ...armResponse }, { ok: true });
+keyupHandler({ isTrusted: true, key: '1', code: 'Digit1' });
+assert.deepStrictEqual(
+  runtimeMessages,
+  [],
+  'releasing the trigger key must neither commit nor disarm a held Command shortcut'
+);
+keyupHandler({ isTrusted: true, key: 'Meta', code: 'MetaLeft' });
+assert.deepStrictEqual(
+  runtimeMessages.map((message) => ({ ...message })),
+  [{ action: 'notifyTabSwitcherShortcutModifierReleased', key: 'Meta' }],
+  'releasing Command should relay exactly one commit request'
+);
+keyupHandler({ isTrusted: true, key: 'Meta', code: 'MetaLeft' });
+assert.strictEqual(
+  runtimeMessages.length,
+  1,
+  'the observer should disarm after the configured modifier is released'
+);
+
+runtimeMessageListener({ action: 'armTabSwitcherShortcutRelease', keys: ['Control'] }, {}, () => {});
+keyupHandler({ isTrusted: true, key: '?', code: 'Slash' });
+assert.strictEqual(runtimeMessages.length, 1, 'releasing Slash must not commit while Control remains held');
+keyupHandler({ isTrusted: true, key: 'Control', code: 'ControlLeft' });
+assert.deepStrictEqual(
+  runtimeMessages.map((message) => ({ ...message })),
+  [
+    { action: 'notifyTabSwitcherShortcutModifierReleased', key: 'Meta' },
+    { action: 'notifyTabSwitcherShortcutModifierReleased', key: 'Control' }
+  ],
+  'Ctrl+Shift+/ should commit only when its primary Control modifier is released'
+);
+
+const quickReleaseCommandStartedAt = Date.now() - 10;
+keyupHandler({ isTrusted: true, key: 'Meta', code: 'MetaRight' });
+runtimeMessageListener({
+  action: 'armTabSwitcherShortcutRelease',
+  keys: ['Meta'],
+  commandStartedAt: quickReleaseCommandStartedAt
+}, {}, () => {});
+assert.deepStrictEqual(
+  runtimeMessages.map((message) => ({ ...message })),
+  [
+    { action: 'notifyTabSwitcherShortcutModifierReleased', key: 'Meta' },
+    { action: 'notifyTabSwitcherShortcutModifierReleased', key: 'Control' },
+    { action: 'notifyTabSwitcherShortcutModifierReleased', key: 'Meta' }
+  ],
+  'a trusted shortcut release that beats the async arm message should be replayed for the same command'
+);
+
+keyupHandler({ isTrusted: true, key: 'Control', code: 'ControlRight' });
+runtimeMessageListener({
+  action: 'armTabSwitcherShortcutRelease',
+  keys: ['Control'],
+  commandStartedAt: Date.now() + 1000
+}, {}, () => {});
+assert.strictEqual(
+  runtimeMessages.length,
+  3,
+  'a release observed before the current command started must not be replayed'
+);
+keyupHandler({ isTrusted: true, key: 'Control', code: 'ControlLeft' });
+assert.deepStrictEqual(
+  runtimeMessages.map((message) => ({ ...message })).at(-1),
+  { action: 'notifyTabSwitcherShortcutModifierReleased', key: 'Control' },
+  'an armed observer should still relay the next live release after rejecting a stale buffered release'
+);
+
+dom.window.close();
+console.log('tab switcher shortcut release relay tests passed');

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -664,12 +664,30 @@ function updateTabSwitcherThumbnailInPage(update, hostId) {
   return host._lumnoTabSwitcherUpdateThumbnail(update) || { ok: true };
 }
 
+function commitOpenTabSwitcherFromShortcutReleaseInPage(hostId) {
+  const host = document.getElementById(hostId);
+  if (!host || typeof host._lumnoTabSwitcherCommitFromShortcutRelease !== 'function') {
+    return { ok: false, committed: false };
+  }
+  return {
+    ok: true,
+    committed: host._lumnoTabSwitcherCommitFromShortcutRelease() === true
+  };
+}
+
 function getFailedOpenTabSwitcherState() {
   return { ok: false, open: false };
 }
 
 function normalizeTabSwitcherHostOkResponse(response) {
   return response && response.ok === true ? true : null;
+}
+
+function normalizeTabSwitcherCommitResponse(response) {
+  if (!response || response.ok !== true || typeof response.committed !== 'boolean') {
+    return null;
+  }
+  return response.committed === true;
 }
 
 function normalizeOpenTabSwitcherStateResponse(response) {
@@ -687,6 +705,18 @@ function normalizeTabSwitcherHostOkScriptResults(results) {
     results.some((item) => item && item.result && item.result.ok === true)
     ? true
     : null;
+}
+
+function normalizeTabSwitcherCommitScriptResults(results) {
+  const result = Array.isArray(results)
+    ? results.find((item) => (
+      item &&
+      item.result &&
+      item.result.ok === true &&
+      typeof item.result.committed === 'boolean'
+    ))
+    : null;
+  return result && result.result ? result.result.committed === true : null;
 }
 
 function normalizeOpenTabSwitcherStateScriptResults(results) {
@@ -828,6 +858,248 @@ function postTabSwitcherThumbnailUpdate(tab, update) {
     scriptFunc: updateTabSwitcherThumbnailInPage,
     scriptArgs: [payload, TAB_SWITCHER_HOST_ID],
     fallbackValue: false
+  });
+}
+
+function commitOpenTabSwitcherFromShortcutReleaseOnTab(tab) {
+  return sendTabSwitcherHostMessage(tab, {
+    action: 'commitOpenTabSwitcherFromShortcutRelease'
+  }, {
+    scriptFunc: commitOpenTabSwitcherFromShortcutReleaseInPage,
+    scriptArgs: [TAB_SWITCHER_HOST_ID],
+    normalizeResponse: normalizeTabSwitcherCommitResponse,
+    normalizeScriptResults: normalizeTabSwitcherCommitScriptResults,
+    fallbackValue: false
+  });
+}
+
+function prepareTabSwitcherShortcutReleaseObserver(tab) {
+  if (!tab || typeof tab.id !== 'number') {
+    return Promise.resolve(false);
+  }
+  if (isTabSwitcherExtensionPageMessageTarget(tab)) {
+    return Promise.resolve(true);
+  }
+  if (!chrome || !chrome.scripting || typeof chrome.scripting.executeScript !== 'function') {
+    return Promise.resolve(false);
+  }
+  return new Promise((resolve) => {
+    try {
+      chrome.scripting.executeScript({
+        target: {
+          tabId: tab.id,
+          allFrames: true
+        },
+        files: ['src/content/tab-switcher-shortcut-release.js']
+      }, () => {
+        const error = chrome.runtime && chrome.runtime.lastError
+          ? chrome.runtime.lastError.message || 'unknown'
+          : '';
+        recordTabSwitcherShortcutDebug(
+          error ? 'release-observer-injection-failed' : 'release-observer-ready',
+          {
+            tabId: tab.id,
+            windowId: typeof tab.windowId === 'number' ? tab.windowId : null,
+            error
+          }
+        );
+        resolve(!error);
+      });
+    } catch (error) {
+      recordTabSwitcherShortcutDebug('release-observer-injection-failed', {
+        tabId: tab.id,
+        windowId: typeof tab.windowId === 'number' ? tab.windowId : null,
+        error: error && error.message ? error.message : String(error || 'unknown')
+      });
+      resolve(false);
+    }
+  });
+}
+
+function prepareTabSwitcherShortcutReleaseObserversInOpenTabs() {
+  if (!chrome || !chrome.tabs || typeof chrome.tabs.query !== 'function') {
+    return;
+  }
+  chrome.tabs.query({}, (tabs) => {
+    if (chrome.runtime && chrome.runtime.lastError) {
+      return;
+    }
+    (Array.isArray(tabs) ? tabs : []).forEach((tab) => {
+      prepareTabSwitcherShortcutReleaseObserver(tab);
+    });
+  });
+}
+
+function findOpenTabSwitcherHostInWindow(windowId) {
+  if (typeof windowId !== 'number' || !chrome || !chrome.tabs || typeof chrome.tabs.query !== 'function') {
+    return Promise.resolve(null);
+  }
+  const readStateWithTimeout = (tab) => new Promise((resolve) => {
+    let settled = false;
+    const finish = (open) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve({ tab, open: open === true });
+    };
+    const timer = setTimeout(() => finish(false), TAB_SWITCHER_HOST_STATE_TIMEOUT_MS);
+    getOpenTabSwitcherState(tab)
+      .then((state) => finish(Boolean(state && state.open === true)))
+      .catch(() => finish(false));
+  });
+  return new Promise((resolve) => {
+    chrome.tabs.query({ windowId }, (tabs) => {
+      if (chrome.runtime && chrome.runtime.lastError) {
+        resolve(null);
+        return;
+      }
+      const knownHostTabId = tabSwitcherHostTabIdByWindowId.get(windowId);
+      const candidates = (Array.isArray(tabs) ? tabs : [])
+        .filter((tab) => tab && typeof tab.id === 'number' && canHostSwitcherSurface(tab))
+        .sort((left, right) => {
+          const leftPriority = left.id === knownHostTabId ? 2 : Number(left.active === true);
+          const rightPriority = right.id === knownHostTabId ? 2 : Number(right.active === true);
+          return rightPriority - leftPriority;
+        });
+      Promise.all(candidates.map(readStateWithTimeout)).then((states) => {
+        const openHost = states.find((state) => state.open === true);
+        resolve(openHost ? openHost.tab : null);
+      }).catch(() => resolve(null));
+    });
+  });
+}
+
+function getTabForTabSwitcherCommit(tabId) {
+  if (typeof tabId !== 'number' || !chrome || !chrome.tabs || typeof chrome.tabs.get !== 'function') {
+    return Promise.resolve(null);
+  }
+  return new Promise((resolve) => {
+    chrome.tabs.get(tabId, (tab) => {
+      if (chrome.runtime && chrome.runtime.lastError) {
+        resolve(null);
+        return;
+      }
+      resolve(tab && typeof tab.id === 'number' ? tab : null);
+    });
+  });
+}
+
+function commitOpenTabSwitcherInWindow(windowId, source) {
+  recordTabSwitcherShortcutDebug('commit-search-start', {
+    windowId,
+    source: String(source || '')
+  });
+  const finishCommit = (hostTab, path) => {
+    recordTabSwitcherShortcutDebug('commit-host-resolved', {
+      windowId,
+      source: String(source || ''),
+      hostTabId: hostTab && typeof hostTab.id === 'number' ? hostTab.id : null,
+      path
+    });
+    if (!hostTab) {
+      return false;
+    }
+    return commitOpenTabSwitcherFromShortcutReleaseOnTab(hostTab).then((didCommit) => {
+      recordTabSwitcherShortcutDebug('commit-finished', {
+        windowId,
+        source: String(source || ''),
+        hostTabId: hostTab.id,
+        committed: didCommit === true
+      });
+      if (didCommit === true && tabSwitcherHostTabIdByWindowId.get(windowId) === hostTab.id) {
+        tabSwitcherHostTabIdByWindowId.delete(windowId);
+      }
+      return didCommit === true;
+    });
+  };
+  const findAndCommit = () => findOpenTabSwitcherHostInWindow(windowId)
+    .then((hostTab) => finishCommit(hostTab, 'window-scan'));
+  const knownHostTabId = tabSwitcherHostTabIdByWindowId.get(windowId);
+  if (typeof knownHostTabId !== 'number') {
+    return findAndCommit().catch(() => false);
+  }
+  return getTabForTabSwitcherCommit(knownHostTabId)
+    .then((hostTab) => finishCommit(hostTab, 'known-host'))
+    .then((didCommit) => {
+      if (didCommit === true) {
+        return true;
+      }
+      if (tabSwitcherHostTabIdByWindowId.get(windowId) === knownHostTabId) {
+        tabSwitcherHostTabIdByWindowId.delete(windowId);
+      }
+      return findAndCommit();
+    })
+    .catch(() => findAndCommit().catch(() => false));
+}
+
+function handleTabSwitcherShortcutModifierReleased(senderTab, releasedKey, callback) {
+  const finish = typeof callback === 'function' ? callback : () => {};
+  if (!senderTab || typeof senderTab.windowId !== 'number') {
+    finish(false);
+    return;
+  }
+  const key = String(releasedKey || '');
+  getConfiguredTabSwitcherShortcut((shortcut) => {
+    const expectedKeys = typeof RECENT_TAB_SWITCHER.getShortcutReleaseEventKeys === 'function'
+      ? RECENT_TAB_SWITCHER.getShortcutReleaseEventKeys(shortcut)
+      : [];
+    if (!expectedKeys.includes(key)) {
+      recordTabSwitcherShortcutDebug('release-rejected', {
+        windowId: senderTab.windowId,
+        key,
+        shortcut,
+        expectedKeys
+      });
+      finish(false);
+      return;
+    }
+    recordTabSwitcherShortcutDebug('release-accepted', {
+      windowId: senderTab.windowId,
+      key,
+      shortcut,
+      expectedKeys
+    });
+    commitOpenTabSwitcherInWindow(senderTab.windowId, 'keyup')
+      .then((didCommit) => finish(didCommit === true))
+      .catch(() => finish(false));
+  });
+}
+
+function armTabSwitcherShortcutReleaseObservers(tabs, windowId, shortcut, commandStartedAt) {
+  if (typeof windowId !== 'number') {
+    return;
+  }
+  const keys = typeof RECENT_TAB_SWITCHER.getShortcutReleaseEventKeys === 'function'
+    ? RECENT_TAB_SWITCHER.getShortcutReleaseEventKeys(shortcut)
+    : [];
+  if (!keys.length) {
+    return;
+  }
+  const message = {
+    action: 'armTabSwitcherShortcutRelease',
+    keys,
+    commandStartedAt: Number(commandStartedAt) || 0
+  };
+  (Array.isArray(tabs) ? tabs : []).forEach((item) => {
+    if (!item || typeof item.id !== 'number' || item.windowId !== windowId) {
+      return;
+    }
+    if (isTabSwitcherExtensionPageMessageTarget(item)) {
+      postTabSwitcherMessageToExtensionPage(item, message, () => {});
+      return;
+    }
+    if (!chrome || !chrome.tabs || typeof chrome.tabs.sendMessage !== 'function') {
+      return;
+    }
+    try {
+      chrome.tabs.sendMessage(item.id, message, () => {
+        void (chrome.runtime && chrome.runtime.lastError);
+      });
+    } catch (error) {
+      // Restricted tabs simply cannot participate in the release relay.
+    }
   });
 }
 
@@ -1241,6 +1513,31 @@ function requestFocusVisibleNewtabInput(source, tabId) {
 }
 
 const HOTKEY_DEBUG_ENABLED = false;
+const TAB_SWITCHER_SHORTCUT_DEBUG_LIMIT = 50;
+const tabSwitcherShortcutDebugEvents = [];
+
+function recordTabSwitcherShortcutDebug(stage, payload) {
+  tabSwitcherShortcutDebugEvents.push({
+    at: new Date().toISOString(),
+    stage: String(stage || ''),
+    ...(payload && typeof payload === 'object' ? payload : {})
+  });
+  if (tabSwitcherShortcutDebugEvents.length > TAB_SWITCHER_SHORTCUT_DEBUG_LIMIT) {
+    tabSwitcherShortcutDebugEvents.splice(
+      0,
+      tabSwitcherShortcutDebugEvents.length - TAB_SWITCHER_SHORTCUT_DEBUG_LIMIT
+    );
+  }
+}
+
+globalThis._lumnoTabSwitcherShortcutDebug = Object.freeze({
+  snapshot() {
+    return tabSwitcherShortcutDebugEvents.map((event) => ({ ...event }));
+  },
+  clear() {
+    tabSwitcherShortcutDebugEvents.length = 0;
+  }
+});
 
 function logHotkeyDebug(stage, payload) {
   if (!HOTKEY_DEBUG_ENABLED) {
@@ -1342,6 +1639,8 @@ const TAB_SWITCHER_HOST_ID = '_x_extension_tab_switcher_host_2026_unique_';
 const tabSwitcherExtensionPagePortsByTabId = new Map();
 const TAB_SWITCHER_OPENING_GUARD_MS = 2000;
 const tabSwitcherOpeningByWindowKey = new Map();
+const TAB_SWITCHER_HOST_STATE_TIMEOUT_MS = 400;
+const tabSwitcherHostTabIdByWindowId = new Map();
 const HOTKEY_DUP_GUARD_MS = 180;
 const PAGE_HOTKEY_NEWTAB_RECOVER_MS = 1200;
 const BROWSER_NEWTAB_PROVIDER_DETECTION_MS = 6000;
@@ -3825,6 +4124,7 @@ function injectTabSwitcherOnTab(hostTab, items, context) {
     tabZoomFactor: tabZoomFactor,
     advanceOnExisting: true,
     suppressInitialShortcutAdvance: context && context.source === 'commands-tab-switcher',
+    shortcut: context && typeof context.shortcut === 'string' ? context.shortcut : 'Alt+Q',
     source: context && context.source ? context.source : ''
   });
   if (isTabSwitcherExtensionPageMessageTarget(hostTab)) {
@@ -4024,7 +4324,11 @@ function advanceExistingTabSwitcherOnTab(tab, source, callback) {
 }
 
 function triggerTabSwitcherForTab(tab, source) {
+  const commandStartedAt = Date.now();
   if (!tabSwitcherEnabledCache) {
+    if (tab && typeof tab.windowId === 'number') {
+      tabSwitcherHostTabIdByWindowId.delete(tab.windowId);
+    }
     logHotkeyDebug('tab-switcher-disabled', { source: source || '' });
     return;
   }
@@ -4033,21 +4337,62 @@ function triggerTabSwitcherForTab(tab, source) {
     openNewtabFallback();
     return;
   }
+  const windowId = typeof tab.windowId === 'number' ? tab.windowId : null;
+  recordTabSwitcherShortcutDebug('command-received', {
+    source: String(source || ''),
+    tabId: tab.id,
+    windowId
+  });
+  // A manifest content script is not retroactively installed into tabs that
+  // were already open when a development extension was reloaded. Start the
+  // trusted keyup observer before any async switcher work so a quick physical
+  // modifier release can be buffered and replayed after the panel opens.
+  const releaseObserverReady = prepareTabSwitcherShortcutReleaseObserver(tab);
   clearScheduledSwitcherThumbnailCapture(tab.id);
   advanceExistingTabSwitcherOnTab(tab, source, (didAdvance) => {
     if (didAdvance) {
+      if (typeof tab.windowId === 'number') {
+        tabSwitcherHostTabIdByWindowId.set(tab.windowId, tab.id);
+      }
+      recordTabSwitcherShortcutDebug('command-advanced', {
+        tabId: tab.id,
+        windowId
+      });
       return;
     }
     const opening = beginTabSwitcherOpening(tab, source);
     if (!opening) {
       return;
     }
-    const finishOpening = createTabSwitcherOpeningFinisher(opening);
+    let openingHostTabId = tab.id;
+    const finishOpeningGuard = createTabSwitcherOpeningFinisher(opening);
+    const finishOpening = (ok) => {
+      finishOpeningGuard();
+      if (ok === true) {
+        if (typeof windowId === 'number' && typeof openingHostTabId === 'number') {
+          tabSwitcherHostTabIdByWindowId.set(windowId, openingHostTabId);
+        }
+        recordTabSwitcherShortcutDebug('switcher-opened', {
+          windowId,
+          hostTabId: openingHostTabId
+        });
+        return;
+      }
+      if (tabSwitcherHostTabIdByWindowId.get(windowId) === openingHostTabId) {
+        tabSwitcherHostTabIdByWindowId.delete(windowId);
+      }
+      recordTabSwitcherShortcutDebug('switcher-open-failed', {
+        windowId
+      });
+    };
     const startupStateReady = Promise.all([
       ensureTabSwitcherStateLoaded(),
       loadFaviconRequestBlacklistItems(),
       loadFaviconEnhancedFetchEnabled()
     ]).catch(() => {});
+    const shortcutReady = new Promise((resolve) => {
+      getConfiguredTabSwitcherShortcut(resolve);
+    });
     const tabQueryReady = new Promise((resolve) => {
       chrome.tabs.query({}, (tabs) => {
         const error = chrome.runtime && chrome.runtime.lastError
@@ -4059,8 +4404,19 @@ function triggerTabSwitcherForTab(tab, source) {
         });
       });
     });
-    Promise.all([startupStateReady, tabQueryReady]).then((results) => {
+    Promise.all([startupStateReady, tabQueryReady, shortcutReady, releaseObserverReady]).then((results) => {
       const tabQuery = results[1] || { error: 'unknown', tabs: [] };
+      const shortcut = typeof results[2] === 'string' && results[2]
+        ? results[2]
+        : 'Alt+Q';
+      const releaseKeys = typeof RECENT_TAB_SWITCHER.getShortcutReleaseEventKeys === 'function'
+        ? RECENT_TAB_SWITCHER.getShortcutReleaseEventKeys(shortcut)
+        : [];
+      recordTabSwitcherShortcutDebug('shortcut-configured', {
+        windowId,
+        shortcut,
+        releaseKeys
+      });
       if (tabQuery.error) {
         logHotkeyDebug('tab-switcher-query-failed', {
           source: source || '',
@@ -4071,6 +4427,17 @@ function triggerTabSwitcherForTab(tab, source) {
       }
       const tabList = tabQuery.tabs;
       const activeTab = tabList.find((item) => item && item.id === tab.id) || tab;
+      const finishOpeningAndArmShortcutRelease = (ok) => {
+        finishOpening(ok);
+        if (ok === true) {
+          armTabSwitcherShortcutReleaseObservers(
+            tabList,
+            activeTab.windowId,
+            shortcut,
+            commandStartedAt
+          );
+        }
+      };
       clearScheduledSwitcherThumbnailCapture(activeTab.id);
       if (shouldTrackSwitcherTab(activeTab)) {
         recordRecentSwitcherTab(activeTab);
@@ -4104,6 +4471,7 @@ function triggerTabSwitcherForTab(tab, source) {
         finishOpening();
         return;
       }
+      openingHostTabId = hostTab.id;
       if (hostTab.id !== activeTab.id) {
         focusWindowAndActivateTab(hostTab.id, hostTab.windowId, (result) => {
           if (!result || result.ok === false) {
@@ -4113,8 +4481,9 @@ function triggerTabSwitcherForTab(tab, source) {
           injectTabSwitcherOnTab(hostTab, items, {
             currentTabId: activeTab.id,
             selectedIndex,
+            shortcut,
             source,
-            onOpenComplete: finishOpening
+            onOpenComplete: finishOpeningAndArmShortcutRelease
           });
         });
         return;
@@ -4122,8 +4491,9 @@ function triggerTabSwitcherForTab(tab, source) {
       injectTabSwitcherOnTab(hostTab, items, {
         currentTabId: activeTab.id,
         selectedIndex,
+        shortcut,
         source,
-        onOpenComplete: finishOpening
+        onOpenComplete: finishOpeningAndArmShortcutRelease
       });
     }).catch(() => {
       finishOpening();
@@ -4328,6 +4698,26 @@ function getConfiguredFallbackShortcut(callback) {
   });
 }
 
+function getConfiguredTabSwitcherShortcut(callback) {
+  const fallbackShortcut = 'Alt+Q';
+  if (!chrome || !chrome.commands || typeof chrome.commands.getAll !== 'function') {
+    callback(fallbackShortcut);
+    return;
+  }
+  chrome.commands.getAll((commands) => {
+    if (chrome.runtime && chrome.runtime.lastError) {
+      callback(fallbackShortcut);
+      return;
+    }
+    const items = Array.isArray(commands) ? commands : [];
+    const command = items.find((item) => item && item.name === SHOW_TAB_SWITCHER_COMMAND_NAME);
+    const shortcut = command && typeof command.shortcut === 'string'
+      ? String(command.shortcut).trim()
+      : '';
+    callback(shortcut || fallbackShortcut);
+  });
+}
+
 function normalizeShortcutFromCommandsValue(value) {
   const text = String(value || '').trim();
   if (!text || text.includes('%')) {
@@ -4484,6 +4874,10 @@ chrome.tabs.onCreated.addListener((tab) => {
 });
 
 chrome.runtime.onInstalled.addListener((details) => {
+  // Static manifest content scripts only apply to future document loads. A
+  // development-extension reload keeps existing tabs alive, so install the
+  // release observer there now instead of waiting for the next shortcut.
+  prepareTabSwitcherShortcutReleaseObserversInOpenTabs();
   if (!details) {
     schedulePersistPinnedTabSnapshot();
     return;
@@ -4522,6 +4916,7 @@ function restoreBackgroundStateOnStartup() {
 
 if (chrome && chrome.runtime && chrome.runtime.onStartup) {
   chrome.runtime.onStartup.addListener(() => {
+    prepareTabSwitcherShortcutReleaseObserversInOpenTabs();
     restoreBackgroundStateOnStartup();
   });
 }
@@ -4585,6 +4980,11 @@ if (chrome && chrome.tabs && chrome.tabs.onRemoved) {
     clearTabSwitchStat(tabId);
     removeRecentSwitcherTab(tabId);
     clearGlobalPipOwnerForTabId(tabId);
+    Array.from(tabSwitcherHostTabIdByWindowId.entries()).forEach(([windowId, hostTabId]) => {
+      if (hostTabId === tabId) {
+        tabSwitcherHostTabIdByWindowId.delete(windowId);
+      }
+    });
     if (removeInfo && removeInfo.isWindowClosing) {
       return;
     }
@@ -4662,7 +5062,8 @@ if (chrome && chrome.windows && chrome.windows.onCreated) {
 }
 
 if (chrome && chrome.windows && chrome.windows.onRemoved) {
-  chrome.windows.onRemoved.addListener(() => {
+  chrome.windows.onRemoved.addListener((windowId) => {
+    tabSwitcherHostTabIdByWindowId.delete(windowId);
     schedulePersistPinnedTabSnapshot({ skipEmptyWhenNoNormalWindows: true });
   });
 }
@@ -5036,6 +5437,7 @@ const BACKGROUND_MESSAGE_ROUTE_GROUPS = Object.freeze({
       'getCopyCurrentUrlCommandShortcut',
       'copyCurrentPageUrl',
       'triggerShowSearchFromPageHotkey',
+      'notifyTabSwitcherShortcutModifierReleased',
       'getShortcutRules'
     ],
     handler: handleShortcutMessage
@@ -5293,6 +5695,13 @@ function handleShortcutMessage(request, sender, sendResponse) {
       triggerShowSearchForTab(senderTab, triggerSource);
       sendResponse({ ok: true });
       return;
+    }
+    case 'notifyTabSwitcherShortcutModifierReleased': {
+      const senderTab = sender && sender.tab ? sender.tab : null;
+      handleTabSwitcherShortcutModifierReleased(senderTab, request && request.key, (didCommit) => {
+        sendResponse({ ok: true, committed: didCommit === true });
+      });
+      return true;
     }
     case 'getShortcutRules': {
       loadShortcutRules().then((items) => {

--- a/src/background/recent-tab-switcher.js
+++ b/src/background/recent-tab-switcher.js
@@ -43,6 +43,86 @@
     }
   }
 
+  function getShortcutCommitModifierEventKey(shortcut) {
+    const shortcutText = String(shortcut || '').trim();
+    const symbolModifiers = Array.from(shortcutText).map((token) => {
+      if (token === '⌥') {
+        return 'Alt';
+      }
+      if (token === '⌃') {
+        return 'Control';
+      }
+      if (token === '⌘') {
+        return 'Meta';
+      }
+      if (token === '⇧') {
+        return 'Shift';
+      }
+      return '';
+    }).filter(Boolean);
+    if (symbolModifiers.length) {
+      return symbolModifiers.find((key) => key !== 'Shift') || symbolModifiers[0] || '';
+    }
+    const parts = shortcutText
+      .split('+')
+      .map((part) => String(part || '').trim().toLowerCase())
+      .filter(Boolean);
+    const modifiers = parts.slice(0, -1).map((token) => {
+      if (token === 'alt' || token === 'option') {
+        return 'Alt';
+      }
+      if (token === 'ctrl' || token === 'control' || token === 'macctrl') {
+        return 'Control';
+      }
+      if (token === 'command' || token === 'cmd' || token === 'meta' || token === 'super') {
+        return 'Meta';
+      }
+      if (token === 'shift') {
+        return 'Shift';
+      }
+      return '';
+    }).filter(Boolean);
+    return modifiers.find((key) => key !== 'Shift') || modifiers[0] || '';
+  }
+
+  function getShortcutTriggerEventKey(shortcut) {
+    const shortcutText = String(shortcut || '').trim();
+    const parts = shortcutText
+      .split('+')
+      .map((part) => String(part || '').trim())
+      .filter(Boolean);
+    const symbolTrigger = /[⌥⌃⌘⇧]/.test(shortcutText)
+      ? shortcutText.replace(/[⌥⌃⌘⇧]/g, '').replace(/^\++/, '').trim()
+      : '';
+    const rawToken = symbolTrigger || String(parts[parts.length - 1] || '');
+    const token = rawToken.toLowerCase();
+    const aliases = {
+      comma: ',',
+      period: '.',
+      slash: '/',
+      backslash: '\\',
+      return: 'Enter',
+      esc: 'Escape',
+      space: ' ',
+      spacebar: ' '
+    };
+    if (aliases[token]) {
+      return aliases[token];
+    }
+    if (/^f\d{1,2}$/.test(token)) {
+      return token.toUpperCase();
+    }
+    return token.length === 1 ? token : rawToken;
+  }
+
+  function getShortcutReleaseEventKeys(shortcut) {
+    const modifierKey = getShortcutCommitModifierEventKey(shortcut);
+    if (!modifierKey) {
+      return [];
+    }
+    return [modifierKey];
+  }
+
   function sanitizeText(value) {
     return String(value || '').replace(/\s+/g, ' ').trim();
   }
@@ -551,6 +631,9 @@
     DEFAULT_LIMIT,
     createRecentTabTracker,
     defaultShouldIncludeTab,
+    getShortcutCommitModifierEventKey,
+    getShortcutTriggerEventKey,
+    getShortcutReleaseEventKeys,
     focusWindowAndActivateTab
   });
 });

--- a/src/content/tab-switcher-shortcut-release.js
+++ b/src/content/tab-switcher-shortcut-release.js
@@ -1,0 +1,147 @@
+(function() {
+  const RUNTIME_KEY = '_x_extension_tab_switcher_shortcut_release_2026_unique_';
+  const previousRuntime = window[RUNTIME_KEY];
+  if (previousRuntime && typeof previousRuntime.cleanup === 'function') {
+    try {
+      previousRuntime.cleanup();
+    } catch (error) {
+      // A listener from the previous extension context may already be invalid.
+    }
+  }
+  const RELEASE_REPLAY_WINDOW_MS = 5000;
+  let armedReleaseKeys = [];
+  const recentTrustedReleaseAtByKey = new Map();
+
+  function normalizeReleaseKey(value) {
+    const key = String(value || '');
+    return key.length === 1 ? key.toLowerCase() : key;
+  }
+
+  function normalizeReleaseCode(value) {
+    const code = String(value || '');
+    if (/^Key[A-Z]$/.test(code)) {
+      return code.slice(3).toLowerCase();
+    }
+    if (/^Digit\d$/.test(code)) {
+      return code.slice(5);
+    }
+    const aliases = {
+      Backquote: '`',
+      Backslash: '\\',
+      BracketLeft: '[',
+      BracketRight: ']',
+      Comma: ',',
+      Equal: '=',
+      Minus: '-',
+      Period: '.',
+      Quote: "'",
+      Semicolon: ';',
+      Slash: '/'
+    };
+    return aliases[code] || '';
+  }
+
+  function getShortcutReleaseCandidates(event) {
+    return Array.from(new Set([
+      normalizeReleaseKey(event && event.key),
+      normalizeReleaseCode(event && event.code)
+    ].filter(Boolean)));
+  }
+
+  function getReleasedShortcutKey(event) {
+    return getShortcutReleaseCandidates(event)
+      .find((key) => armedReleaseKeys.includes(key)) || '';
+  }
+
+  function rememberTrustedShortcutRelease(event) {
+    const releasedAt = Date.now();
+    recentTrustedReleaseAtByKey.forEach((observedAt, key) => {
+      if ((releasedAt - observedAt) > RELEASE_REPLAY_WINDOW_MS) {
+        recentTrustedReleaseAtByKey.delete(key);
+      }
+    });
+    getShortcutReleaseCandidates(event).forEach((key) => {
+      recentTrustedReleaseAtByKey.set(key, releasedAt);
+    });
+  }
+
+  function getBufferedReleasedShortcutKey(keys, commandStartedAt) {
+    const startedAt = Number(commandStartedAt);
+    if (!Number.isFinite(startedAt) || startedAt <= 0) {
+      return '';
+    }
+    const now = Date.now();
+    return keys.find((key) => {
+      const observedAt = recentTrustedReleaseAtByKey.get(key);
+      return Number.isFinite(observedAt) &&
+        observedAt >= startedAt &&
+        (now - observedAt) <= RELEASE_REPLAY_WINDOW_MS;
+    }) || '';
+  }
+
+  function relayTabSwitcherShortcutRelease(key) {
+    if (!key) {
+      return;
+    }
+    armedReleaseKeys = [];
+    recentTrustedReleaseAtByKey.delete(key);
+    try {
+      chrome.runtime.sendMessage({
+        action: 'notifyTabSwitcherShortcutModifierReleased',
+        key
+      }, () => {
+        void (chrome.runtime && chrome.runtime.lastError);
+      });
+    } catch (error) {
+      // Ignore stale extension contexts while a tab or the extension reloads.
+    }
+  }
+
+  const runtimeMessageListener = (request, _sender, sendResponse) => {
+      if (!request || request.action !== 'armTabSwitcherShortcutRelease') {
+        return;
+      }
+      armedReleaseKeys = (Array.isArray(request.keys) ? request.keys : [request.key])
+        .map(normalizeReleaseKey)
+        .filter(Boolean);
+      const bufferedKey = getBufferedReleasedShortcutKey(
+        armedReleaseKeys,
+        request.commandStartedAt
+      );
+      if (bufferedKey) {
+        relayTabSwitcherShortcutRelease(bufferedKey);
+      }
+      sendResponse({ ok: armedReleaseKeys.length > 0 || Boolean(bufferedKey) });
+  };
+
+  if (chrome && chrome.runtime && chrome.runtime.onMessage) {
+    chrome.runtime.onMessage.addListener(runtimeMessageListener);
+  }
+
+  function notifyTabSwitcherShortcutModifierReleased(event) {
+    if (!event || event.isTrusted !== true) {
+      return;
+    }
+    rememberTrustedShortcutRelease(event);
+    const key = getReleasedShortcutKey(event);
+    if (!key) {
+      return;
+    }
+    relayTabSwitcherShortcutRelease(key);
+  }
+
+  window.addEventListener('keyup', notifyTabSwitcherShortcutModifierReleased, true);
+  window[RUNTIME_KEY] = Object.freeze({
+    cleanup() {
+      window.removeEventListener('keyup', notifyTabSwitcherShortcutModifierReleased, true);
+      if (chrome && chrome.runtime && chrome.runtime.onMessage &&
+          typeof chrome.runtime.onMessage.removeListener === 'function') {
+        try {
+          chrome.runtime.onMessage.removeListener(runtimeMessageListener);
+        } catch (error) {
+          // Ignore a listener that belongs to an invalidated extension context.
+        }
+      }
+    }
+  });
+})();

--- a/src/overlay/tab-switcher-page-bridge.js
+++ b/src/overlay/tab-switcher-page-bridge.js
@@ -7,11 +7,100 @@
   const TAB_SWITCHER_HOST_ID = '_x_extension_tab_switcher_host_2026_unique_';
   const TAB_SWITCHER_ADVANCE_EVENT = '_x_extension_tab_switcher_advance_command_2026_unique_';
   const TAB_SWITCHER_EXTENSION_PAGE_PORT_NAME = 'lumno-tab-switcher-extension-page';
+  const TAB_SWITCHER_RELEASE_REPLAY_WINDOW_MS = 5000;
   const chromeApi = typeof chrome !== 'undefined' ? chrome : null;
   let extensionPagePort = null;
   let extensionPagePortReconnectTimer = null;
   let extensionPagePortClosed = false;
   let extensionPageTabId = null;
+  let armedReleaseKeys = [];
+  const recentTrustedReleaseAtByKey = new Map();
+
+  function normalizeTabSwitcherReleaseKey(value) {
+    const key = String(value || '');
+    return key.length === 1 ? key.toLowerCase() : key;
+  }
+
+  function normalizeTabSwitcherReleaseCode(value) {
+    const code = String(value || '');
+    if (/^Key[A-Z]$/.test(code)) {
+      return code.slice(3).toLowerCase();
+    }
+    if (/^Digit\d$/.test(code)) {
+      return code.slice(5);
+    }
+    const aliases = {
+      Backquote: '`',
+      Backslash: '\\',
+      BracketLeft: '[',
+      BracketRight: ']',
+      Comma: ',',
+      Equal: '=',
+      Minus: '-',
+      Period: '.',
+      Quote: "'",
+      Semicolon: ';',
+      Slash: '/'
+    };
+    return aliases[code] || '';
+  }
+
+  function getTabSwitcherShortcutReleaseCandidates(event) {
+    return Array.from(new Set([
+      normalizeTabSwitcherReleaseKey(event && event.key),
+      normalizeTabSwitcherReleaseCode(event && event.code)
+    ].filter(Boolean)));
+  }
+
+  function getReleasedTabSwitcherShortcutKey(event) {
+    return getTabSwitcherShortcutReleaseCandidates(event)
+      .find((key) => armedReleaseKeys.includes(key)) || '';
+  }
+
+  function rememberTrustedTabSwitcherShortcutRelease(event) {
+    const releasedAt = Date.now();
+    recentTrustedReleaseAtByKey.forEach((observedAt, key) => {
+      if ((releasedAt - observedAt) > TAB_SWITCHER_RELEASE_REPLAY_WINDOW_MS) {
+        recentTrustedReleaseAtByKey.delete(key);
+      }
+    });
+    getTabSwitcherShortcutReleaseCandidates(event).forEach((key) => {
+      recentTrustedReleaseAtByKey.set(key, releasedAt);
+    });
+  }
+
+  function getBufferedTabSwitcherShortcutReleaseKey(keys, commandStartedAt) {
+    const startedAt = Number(commandStartedAt);
+    if (!Number.isFinite(startedAt) || startedAt <= 0) {
+      return '';
+    }
+    const now = Date.now();
+    return keys.find((key) => {
+      const observedAt = recentTrustedReleaseAtByKey.get(key);
+      return Number.isFinite(observedAt) &&
+        observedAt >= startedAt &&
+        (now - observedAt) <= TAB_SWITCHER_RELEASE_REPLAY_WINDOW_MS;
+    }) || '';
+  }
+
+  function relayTabSwitcherShortcutRelease(key) {
+    if (!key || !chromeApi || !chromeApi.runtime ||
+        typeof chromeApi.runtime.sendMessage !== 'function') {
+      return;
+    }
+    armedReleaseKeys = [];
+    recentTrustedReleaseAtByKey.delete(key);
+    try {
+      chromeApi.runtime.sendMessage({
+        action: 'notifyTabSwitcherShortcutModifierReleased',
+        key
+      }, () => {
+        void (chromeApi.runtime && chromeApi.runtime.lastError);
+      });
+    } catch (error) {
+      // Ignore stale extension page contexts during reload.
+    }
+  }
 
   function normalizeTabSwitcherAdvanceOffset(value) {
     const offset = Math.trunc(Number(value));
@@ -43,6 +132,17 @@
     }
     document.dispatchEvent(createTabSwitcherAdvanceEvent(request && request.offset));
     return { ok: true, advanced: true };
+  }
+
+  function commitOpenTabSwitcherFromShortcutRelease() {
+    const host = document.getElementById(TAB_SWITCHER_HOST_ID);
+    if (!host || typeof host._lumnoTabSwitcherCommitFromShortcutRelease !== 'function') {
+      return { ok: false, committed: false };
+    }
+    return {
+      ok: true,
+      committed: host._lumnoTabSwitcherCommitFromShortcutRelease() === true
+    };
   }
 
   function openTabSwitcherFromCommand(request) {
@@ -120,6 +220,22 @@
     if (request.action === 'advanceOpenTabSwitcherFromCommand') {
       return advanceOpenTabSwitcherFromCommand(request);
     }
+    if (request.action === 'armTabSwitcherShortcutRelease') {
+      armedReleaseKeys = (Array.isArray(request.keys) ? request.keys : [request.key])
+        .map(normalizeTabSwitcherReleaseKey)
+        .filter(Boolean);
+      const bufferedKey = getBufferedTabSwitcherShortcutReleaseKey(
+        armedReleaseKeys,
+        request.commandStartedAt
+      );
+      if (bufferedKey) {
+        relayTabSwitcherShortcutRelease(bufferedKey);
+      }
+      return { ok: armedReleaseKeys.length > 0 || Boolean(bufferedKey) };
+    }
+    if (request.action === 'commitOpenTabSwitcherFromShortcutRelease') {
+      return commitOpenTabSwitcherFromShortcutRelease();
+    }
     if (request.action === 'openTabSwitcherFromCommand') {
       return openTabSwitcherFromCommand(request);
     }
@@ -180,6 +296,7 @@
       ok: Boolean(response && response.ok),
       reason: response && response.reason ? String(response.reason) : '',
       advanced: response && typeof response.advanced === 'boolean' ? response.advanced : null,
+      committed: response && typeof response.committed === 'boolean' ? response.committed : null,
       open: response && typeof response.open === 'boolean' ? response.open : null,
       suppressed: Boolean(response && response.suppressed)
     });
@@ -237,6 +354,21 @@
       sendResponse(response);
     });
   }
+
+  function notifyTabSwitcherShortcutModifierReleased(event) {
+    if (!event || event.isTrusted !== true || !chromeApi || !chromeApi.runtime ||
+        typeof chromeApi.runtime.sendMessage !== 'function') {
+      return;
+    }
+    rememberTrustedTabSwitcherShortcutRelease(event);
+    const key = getReleasedTabSwitcherShortcutKey(event);
+    if (!key) {
+      return;
+    }
+    relayTabSwitcherShortcutRelease(key);
+  }
+
+  window.addEventListener('keyup', notifyTabSwitcherShortcutModifierReleased, true);
 
   window.addEventListener('pagehide', () => {
     extensionPagePortClosed = true;

--- a/src/overlay/tab-switcher.js
+++ b/src/overlay/tab-switcher.js
@@ -1172,7 +1172,7 @@
         }
         return;
       }
-      if (event.key === 'Alt') {
+      if (event.key === 'Alt' || event.key === 'Meta') {
         suppressInitialShortcutAdvanceUntilQKeyup = false;
         stopHandledKeyEvent(event);
         switchToSelected();

--- a/src/overlay/tab-switcher.js
+++ b/src/overlay/tab-switcher.js
@@ -84,6 +84,17 @@
     };
   }
 
+  function commitOpenSwitcherFromShortcutReleaseMessage() {
+    const host = document.getElementById(HOST_ID);
+    if (!host || typeof host._lumnoTabSwitcherCommitFromShortcutRelease !== 'function') {
+      return { ok: false, committed: false };
+    }
+    return {
+      ok: true,
+      committed: host._lumnoTabSwitcherCommitFromShortcutRelease() === true
+    };
+  }
+
   function openSwitcherFromMessage(request) {
     const toggle = window._x_extension_toggleTabSwitcher_2026_unique_;
     if (typeof toggle !== 'function') {
@@ -118,6 +129,10 @@
         sendResponse(advanceOpenSwitcherFromMessage(request));
         return true;
       }
+      if (request.action === 'commitOpenTabSwitcherFromShortcutRelease') {
+        sendResponse(commitOpenSwitcherFromShortcutReleaseMessage());
+        return true;
+      }
       if (request.action !== 'openTabSwitcherFromCommand') {
         return;
       }
@@ -140,6 +155,110 @@
   function normalizeAdvanceOffset(value) {
     const offset = Math.trunc(Number(value));
     return Number.isFinite(offset) && offset !== 0 ? offset : 1;
+  }
+
+  function normalizeTabSwitcherShortcutKey(value) {
+    const key = String(value || '').trim().toLowerCase();
+    const aliases = {
+      comma: ',',
+      period: '.',
+      slash: '/',
+      backslash: '\\',
+      return: 'enter',
+      esc: 'escape',
+      space: ' ',
+      spacebar: ' '
+    };
+    return aliases[key] || key;
+  }
+
+  function normalizeTabSwitcherShortcutCode(value) {
+    const code = String(value || '');
+    if (/^Key[A-Z]$/.test(code)) {
+      return code.slice(3).toLowerCase();
+    }
+    if (/^Digit\d$/.test(code)) {
+      return code.slice(5);
+    }
+    const aliases = {
+      Backquote: '`',
+      Backslash: '\\',
+      BracketLeft: '[',
+      BracketRight: ']',
+      Comma: ',',
+      Equal: '=',
+      Minus: '-',
+      Period: '.',
+      Quote: "'",
+      Semicolon: ';',
+      Slash: '/'
+    };
+    return aliases[code] || '';
+  }
+
+  function getTabSwitcherShortcutModifier(value) {
+    const token = String(value || '').trim().toLowerCase();
+    if (token === 'alt' || token === 'option') {
+      return { eventKey: 'Alt', flag: 'altKey' };
+    }
+    if (token === 'ctrl' || token === 'control' || token === 'macctrl') {
+      return { eventKey: 'Control', flag: 'ctrlKey' };
+    }
+    if (token === 'command' || token === 'cmd' || token === 'meta' || token === 'super') {
+      return { eventKey: 'Meta', flag: 'metaKey' };
+    }
+    if (token === 'shift') {
+      return { eventKey: 'Shift', flag: 'shiftKey' };
+    }
+    return null;
+  }
+
+  function parseTabSwitcherShortcut(value) {
+    const shortcutText = String(value || 'Alt+Q').trim();
+    const parts = shortcutText
+      .split('+')
+      .map((part) => String(part || '').trim())
+      .filter(Boolean);
+    const hasSymbolModifiers = /[⌥⌃⌘⇧]/.test(shortcutText);
+    const symbolTrigger = hasSymbolModifiers
+      ? shortcutText.replace(/[⌥⌃⌘⇧]/g, '').replace(/^\++/, '').trim()
+      : '';
+    const triggerKey = normalizeTabSwitcherShortcutKey(symbolTrigger || parts.pop() || 'Q');
+    const modifiers = hasSymbolModifiers
+      ? Array.from(shortcutText).map((token) => {
+        if (token === '⌥') {
+          return { eventKey: 'Alt', flag: 'altKey' };
+        }
+        if (token === '⌃') {
+          return { eventKey: 'Control', flag: 'ctrlKey' };
+        }
+        if (token === '⌘') {
+          return { eventKey: 'Meta', flag: 'metaKey' };
+        }
+        if (token === '⇧') {
+          return { eventKey: 'Shift', flag: 'shiftKey' };
+        }
+        return null;
+      }).filter(Boolean)
+      : parts.map(getTabSwitcherShortcutModifier).filter(Boolean);
+    const commitModifier = modifiers.find((modifier) => modifier.eventKey !== 'Shift') || modifiers[0] || null;
+    return {
+      triggerKey,
+      commitModifierEventKey: commitModifier ? commitModifier.eventKey : '',
+      commitModifierFlag: commitModifier ? commitModifier.flag : ''
+    };
+  }
+
+  function isTabSwitcherShortcutTriggerEvent(shortcut, event) {
+    const eventKeys = [
+      normalizeTabSwitcherShortcutKey(event && event.key),
+      normalizeTabSwitcherShortcutCode(event && event.code)
+    ].filter(Boolean);
+    return eventKeys.includes(shortcut.triggerKey);
+  }
+
+  function isTabSwitcherCommitModifierPressed(shortcut, event) {
+    return Boolean(shortcut.commitModifierFlag && event && event[shortcut.commitModifierFlag] === true);
   }
 
   function normalizeSwitcherThemeMode(mode) {
@@ -989,6 +1108,7 @@
         typeof tabSwitcherReactViewApi.createTabSwitcherView !== 'function') {
       return { ok: false, reason: 'react-view-unavailable' };
     }
+    const shortcut = parseTabSwitcherShortcut(context.shortcut);
 
     const host = document.createElement('div');
     host.id = HOST_ID;
@@ -1006,6 +1126,7 @@
     shadow.appendChild(style);
 
     let selectedIndex = clampSelectedIndex(context.selectedIndex, tabs.length);
+    let allowRelayedShortcutReleaseActivation = false;
     let tabSwitcherReactView = tabSwitcherReactViewApi.createTabSwitcherView({
       document,
       root: shadow,
@@ -1023,7 +1144,7 @@
         renderSelection();
       },
       onActivate(index, event) {
-        if (!event || event.isTrusted !== true) {
+        if (!event || (event.isTrusted !== true && !allowRelayedShortcutReleaseActivation)) {
           return;
         }
         stopHandledKeyEvent(event);
@@ -1048,7 +1169,7 @@
     switcherThemeController.start();
 
     let didRequestSwitch = false;
-    let suppressInitialShortcutAdvanceUntilQKeyup = context.suppressInitialShortcutAdvance === true;
+    let suppressInitialShortcutAdvanceUntilTriggerKeyup = context.suppressInitialShortcutAdvance === true;
 
     function renderSelection() {
       tabSwitcherReactView.updateSelection(selectedIndex);
@@ -1064,12 +1185,12 @@
 
     function switchToSelected() {
       if (didRequestSwitch) {
-        return;
+        return false;
       }
       const selected = tabs[selectedIndex];
       if (!selected || typeof selected.id !== 'number') {
         close();
-        return;
+        return false;
       }
       didRequestSwitch = true;
       chrome.runtime.sendMessage({
@@ -1079,6 +1200,25 @@
       }, () => {
         close();
       });
+      return true;
+    }
+
+    function clickSelectedCardFromShortcutRelease() {
+      const buttons = tabSwitcherReactView && Array.isArray(tabSwitcherReactView.buttons)
+        ? tabSwitcherReactView.buttons
+        : [];
+      const selectedButton = buttons[selectedIndex];
+      if (!selectedButton || typeof selectedButton.click !== 'function') {
+        return switchToSelected();
+      }
+      const wasRequested = didRequestSwitch;
+      allowRelayedShortcutReleaseActivation = true;
+      try {
+        selectedButton.click();
+      } finally {
+        allowRelayedShortcutReleaseActivation = false;
+      }
+      return !wasRequested && didRequestSwitch;
     }
 
     function selectByOffset(offset) {
@@ -1087,17 +1227,20 @@
     }
 
     function shouldSuppressInitialShortcutAdvance() {
-      return suppressInitialShortcutAdvanceUntilQKeyup;
+      return suppressInitialShortcutAdvanceUntilTriggerKeyup;
     }
 
     function advanceSelectionFromShortcut(offset) {
-      suppressInitialShortcutAdvanceUntilQKeyup = false;
+      suppressInitialShortcutAdvanceUntilTriggerKeyup = false;
       selectByOffset(offset);
       return true;
     }
 
     host._lumnoTabSwitcherAdvance = function(offset) {
       return advanceSelectionFromShortcut(normalizeAdvanceOffset(offset));
+    };
+    host._lumnoTabSwitcherCommitFromShortcutRelease = function() {
+      return clickSelectedCardFromShortcutRelease();
     };
 
     function handleExternalAdvance(event) {
@@ -1123,18 +1266,17 @@
       if (!event || event.isTrusted !== true) {
         return;
       }
-      const keyText = String(event.key || '').toLowerCase();
       if (event.key === 'Tab') {
         stopHandledKeyEvent(event);
         selectByOffset(event.shiftKey ? -1 : 1);
         return;
       }
-      if (keyText === 'q') {
+      if (isTabSwitcherShortcutTriggerEvent(shortcut, event)) {
         stopHandledKeyEvent(event);
-        if (shouldSuppressInitialShortcutAdvance() && event.altKey) {
+        if (shouldSuppressInitialShortcutAdvance() && isTabSwitcherCommitModifierPressed(shortcut, event)) {
           return;
         }
-        suppressInitialShortcutAdvanceUntilQKeyup = false;
+        suppressInitialShortcutAdvanceUntilTriggerKeyup = false;
         selectByOffset(1);
         return;
       }
@@ -1163,19 +1305,16 @@
       if (!event || event.isTrusted !== true) {
         return;
       }
-      const keyText = String(event.key || '').toLowerCase();
-      if (keyText === 'q') {
-        suppressInitialShortcutAdvanceUntilQKeyup = false;
+      if (isTabSwitcherShortcutTriggerEvent(shortcut, event)) {
+        suppressInitialShortcutAdvanceUntilTriggerKeyup = false;
         stopHandledKeyEvent(event);
-        if (!event.altKey) {
-          switchToSelected();
-        }
         return;
       }
-      if (event.key === 'Alt' || event.key === 'Meta') {
-        suppressInitialShortcutAdvanceUntilQKeyup = false;
+      if (shortcut.commitModifierEventKey &&
+          event.key === shortcut.commitModifierEventKey) {
+        suppressInitialShortcutAdvanceUntilTriggerKeyup = false;
         stopHandledKeyEvent(event);
-        switchToSelected();
+        clickSelectedCardFromShortcutRelease();
       }
     }
 
@@ -1209,6 +1348,7 @@
         tabSwitcherReactView = null;
       }
       delete host._lumnoTabSwitcherUpdateThumbnail;
+      delete host._lumnoTabSwitcherCommitFromShortcutRelease;
     };
     window.addEventListener('keydown', handleKeydown, true);
     window.addEventListener('keyup', handleKeyup, true);


### PR DESCRIPTION
## What changed

- Commit the selected recent tab when the macOS Command key is released.
- Preserve the existing Option+Q behavior.
- Add source-contract and runtime regression coverage for Command-based shortcuts such as Command+E.

## Root cause

The tab switcher only treated an `Alt` keyup as completion of the hold-to-switch interaction. A browser command assigned to `Command+E` could therefore open and advance the switcher, but releasing Command never sent the `switchToTab` request.

## Validation

- Legacy test suite: 122 test files passed.
- React test suite: 45 files / 231 tests passed.
- React builds, TypeScript typecheck, JavaScript syntax checks, and manifest resource checks passed.
- Browser harness confirmed the actual React switcher renders with the recent tab selected and no console warnings/errors. The browser automation layer marks generated key events as untrusted, so the trusted `Meta` keyup activation path is covered by the runtime regression test.
