### PR TITLE
修复：x.com 等动态图标站点被单页头像污染 favicon 缓存

### DIFF
--- a/scripts/test-favicon-utils.js
+++ b/scripts/test-favicon-utils.js
@@ -303,6 +303,16 @@ assert.strictEqual(
   'HTTP pages should prefer the extension _favicon candidate'
 );
 assert.strictEqual(
+  utils.getFaviconPersistCacheKey('https://Example.com/docs?mode=compact#section', 'example.com'),
+  'page:https://example.com/docs?mode=compact',
+  'persisted favicon caches should isolate HTTP pages while ignoring fragments'
+);
+assert.strictEqual(
+  utils.getFaviconPersistCacheKey('chrome://extensions/', 'extensions'),
+  'extensions',
+  'non-web pages should retain the existing fallback cache key'
+);
+assert.strictEqual(
   resolver.getPageFaviconCandidateUrl('chrome://extensions/'),
   'chrome-extension://abc/_favicon/?pageUrl=chrome%3A%2F%2Fextensions%2F&size=128',
   'browser-internal pages should use the browser-page _favicon candidate'

--- a/scripts/test-newtab-favicon-proxy-upgrade.js
+++ b/scripts/test-newtab-favicon-proxy-upgrade.js
@@ -263,13 +263,14 @@ function createRuntime(options) {
 (async () => {
   const persistedDataUrl = 'data:image/png;base64,cGVyc2lzdGVk';
   const persistedWrites = [];
+  const pageCacheKey = 'page:https://m2.futurecomm.cn/';
   const persistedRuntime = createRuntime({
     getPersistedFaviconEntry(cacheKey) {
-      assert.strictEqual(cacheKey, 'futurecomm.cn');
+      assert.strictEqual(cacheKey, pageCacheKey);
       return { url: primaryUrl, updatedAt: Date.now() - 1 };
     },
     getPersistedFaviconDataEntry(cacheKey) {
-      assert.strictEqual(cacheKey, 'futurecomm.cn');
+      assert.strictEqual(cacheKey, pageCacheKey);
       return { dataUrl: persistedDataUrl, updatedAt: Date.now() };
     },
     setPersistedFaviconUrl(cacheKey, url) {
@@ -293,15 +294,53 @@ function createRuntime(options) {
   );
   assert.strictEqual(
     persistedImg.getAttribute('data-x-nt-favicon-cache-key'),
-    'futurecomm.cn',
-    'theme-aware shortcut favicons should keep a stable host cache key'
+    pageCacheKey,
+    'theme-aware favicons should keep a stable page cache key'
   );
   persistedImg.dispatchEvent('load');
   await wait(4);
   assert.deepStrictEqual(
     persistedWrites[0],
-    { cacheKey: 'futurecomm.cn', type: 'data', value: persistedDataUrl },
+    { cacheKey: pageCacheKey, type: 'data', value: persistedDataUrl },
     'confirmed persisted favicon data should refresh its local cache entry'
+  );
+
+  const profilePageUrl = 'https://x.com/creator';
+  const homePageUrl = 'https://x.com/home';
+  const profileCacheKey = `page:${profilePageUrl}`;
+  const homeCacheKey = `page:${homePageUrl}`;
+  const profileIcon = 'data:image/png;base64,cHJvZmlsZQ==';
+  const homeIcon = 'data:image/png;base64,aG9tZQ==';
+  const sameHostCacheReads = [];
+  const sameHostRuntime = createRuntime({
+    getPersistedFaviconEntry(cacheKey) {
+      sameHostCacheReads.push(cacheKey);
+      return null;
+    },
+    getPersistedFaviconDataEntry(cacheKey) {
+      sameHostCacheReads.push(cacheKey);
+      if (cacheKey === profileCacheKey) {
+        return { dataUrl: profileIcon, updatedAt: Date.now() };
+      }
+      if (cacheKey === homeCacheKey) {
+        return { dataUrl: homeIcon, updatedAt: Date.now() };
+      }
+      if (cacheKey === 'x.com') {
+        return { dataUrl: profileIcon, updatedAt: Date.now() };
+      }
+      return null;
+    }
+  });
+  const profileImg = createFakeImage();
+  const homeImg = createFakeImage();
+  sameHostRuntime.attachFaviconWithFallbacks(profileImg, profilePageUrl, 'x.com');
+  sameHostRuntime.attachFaviconWithFallbacks(homeImg, homePageUrl, 'x.com');
+  assert.strictEqual(profileImg.src, profileIcon);
+  assert.strictEqual(homeImg.src, homeIcon);
+  assert.deepStrictEqual(
+    sameHostCacheReads,
+    [profileCacheKey, profileCacheKey, homeCacheKey, homeCacheKey],
+    'same-host pages should never read the legacy shared host favicon entry'
   );
 
   const shortcutCachedDataUrl = 'data:image/png;base64,c2hvcnRjdXQtY2FjaGU=';

--- a/src/newtab/favicon-view.js
+++ b/src/newtab/favicon-view.js
@@ -18,6 +18,9 @@
     const shouldAvoidDirectFaviconForHost = typeof config.shouldAvoidDirectFaviconForHost === 'function'
       ? config.shouldAvoidDirectFaviconForHost
       : (() => false);
+    const shouldSkipPersistedFaviconForHost = typeof config.shouldSkipPersistedFaviconForHost === 'function'
+      ? config.shouldSkipPersistedFaviconForHost
+      : (() => false);
     const isEnhancedFaviconFetchEnabled = typeof config.isEnhancedFaviconFetchEnabled === 'function'
       ? config.isEnhancedFaviconFetchEnabled
       : (() => true);
@@ -399,7 +402,10 @@
       const session = img._xThemeFaviconSession;
       const hostKey = host || getHostFromUrl(url);
       const cacheKey = String(hostKey || url || '').trim();
-      const skipPersisted = Boolean(optionsArg && optionsArg.skipPersisted === true);
+      const skipPersisted = Boolean(
+        (optionsArg && optionsArg.skipPersisted === true) ||
+        shouldSkipPersistedFaviconForHost(hostKey)
+      );
       const persistedDataEntry = !skipPersisted && cacheKey
         ? getPersistedFaviconDataEntry(cacheKey)
         : null;

--- a/src/newtab/favicon-view.js
+++ b/src/newtab/favicon-view.js
@@ -18,9 +18,6 @@
     const shouldAvoidDirectFaviconForHost = typeof config.shouldAvoidDirectFaviconForHost === 'function'
       ? config.shouldAvoidDirectFaviconForHost
       : (() => false);
-    const shouldSkipPersistedFaviconForHost = typeof config.shouldSkipPersistedFaviconForHost === 'function'
-      ? config.shouldSkipPersistedFaviconForHost
-      : (() => false);
     const isEnhancedFaviconFetchEnabled = typeof config.isEnhancedFaviconFetchEnabled === 'function'
       ? config.isEnhancedFaviconFetchEnabled
       : (() => true);
@@ -401,11 +398,10 @@
       img._xThemeFaviconSession = (img._xThemeFaviconSession || 0) + 1;
       const session = img._xThemeFaviconSession;
       const hostKey = host || getHostFromUrl(url);
-      const cacheKey = String(hostKey || url || '').trim();
-      const skipPersisted = Boolean(
-        (optionsArg && optionsArg.skipPersisted === true) ||
-        shouldSkipPersistedFaviconForHost(hostKey)
-      );
+      const cacheKey = typeof faviconUtils.getFaviconPersistCacheKey === 'function'
+        ? faviconUtils.getFaviconPersistCacheKey(url, hostKey)
+        : String(hostKey || url || '').trim();
+      const skipPersisted = Boolean(optionsArg && optionsArg.skipPersisted === true);
       const persistedDataEntry = !skipPersisted && cacheKey
         ? getPersistedFaviconDataEntry(cacheKey)
         : null;

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -6050,6 +6050,7 @@
     isBlockedLocalFaviconUrl,
     shouldBlockFaviconForHost,
     shouldAvoidDirectFaviconForHost,
+    shouldSkipPersistedFaviconForHost,
     isEnhancedFaviconFetchEnabled: isNewtabEnhancedFaviconFetchEnabled,
     getStrictFaviconReason: getNewtabStrictFaviconReason,
     logFaviconDecision: logNewtabFaviconDecision,
@@ -11775,6 +11776,12 @@
     return typeof FAVICON_UTILS.shouldAvoidDirectFaviconForHost === 'function'
       ? FAVICON_UTILS.shouldAvoidDirectFaviconForHost(hostname)
       : (isLocalNetworkHost(hostname) || isSuspiciousLocalFaviconHost(hostname));
+  }
+
+  function shouldSkipPersistedFaviconForHost(hostname) {
+    return typeof FAVICON_UTILS.shouldSkipPersistedFaviconForHost === 'function'
+      ? FAVICON_UTILS.shouldSkipPersistedFaviconForHost(hostname)
+      : false;
   }
 
   function normalizeSearchBlacklistMatchModes(value) {

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -6050,7 +6050,6 @@
     isBlockedLocalFaviconUrl,
     shouldBlockFaviconForHost,
     shouldAvoidDirectFaviconForHost,
-    shouldSkipPersistedFaviconForHost,
     isEnhancedFaviconFetchEnabled: isNewtabEnhancedFaviconFetchEnabled,
     getStrictFaviconReason: getNewtabStrictFaviconReason,
     logFaviconDecision: logNewtabFaviconDecision,
@@ -11776,12 +11775,6 @@
     return typeof FAVICON_UTILS.shouldAvoidDirectFaviconForHost === 'function'
       ? FAVICON_UTILS.shouldAvoidDirectFaviconForHost(hostname)
       : (isLocalNetworkHost(hostname) || isSuspiciousLocalFaviconHost(hostname));
-  }
-
-  function shouldSkipPersistedFaviconForHost(hostname) {
-    return typeof FAVICON_UTILS.shouldSkipPersistedFaviconForHost === 'function'
-      ? FAVICON_UTILS.shouldSkipPersistedFaviconForHost(hostname)
-      : false;
   }
 
   function normalizeSearchBlacklistMatchModes(value) {

--- a/src/shared/favicon-utils.js
+++ b/src/shared/favicon-utils.js
@@ -995,6 +995,19 @@
     return isLocalNetworkHost(hostname) || isSuspiciousLocalFaviconHost(hostname);
   }
 
+  // Hosts whose pages serve per-page dynamic favicons (e.g. X serves the
+  // author avatar on tweet/profile pages). Persisting a per-host favicon for
+  // them would leak one page's icon onto every other page of the same host.
+  const DYNAMIC_PAGE_FAVICON_HOSTS = new Set([
+    'x.com',
+    'twitter.com'
+  ]);
+
+  function shouldSkipPersistedFaviconForHost(hostname) {
+    const host = normalizeFaviconHost(hostname);
+    return Boolean(host && DYNAMIC_PAGE_FAVICON_HOSTS.has(host));
+  }
+
   function getFaviconHostPolicy(hostname, options) {
     const config = options || {};
     const shouldBlockHost = typeof config.shouldBlockFaviconForHost === 'function'
@@ -1509,6 +1522,7 @@
     shouldSkipThemeUpgradeCandidate,
     shouldBlockFaviconForHost,
     shouldBlockDirectFaviconHost,
-    shouldAvoidDirectFaviconForHost
+    shouldAvoidDirectFaviconForHost,
+    shouldSkipPersistedFaviconForHost
   });
 });

--- a/src/shared/favicon-utils.js
+++ b/src/shared/favicon-utils.js
@@ -237,6 +237,20 @@
     return current;
   }
 
+  function getFaviconPersistCacheKey(pageUrl, fallbackKey) {
+    const canonicalPageUrl = getCanonicalPageUrlForFavicon(pageUrl);
+    try {
+      const parsed = new URL(canonicalPageUrl);
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        parsed.hash = '';
+        return `page:${parsed.href}`;
+      }
+    } catch (e) {
+      // Non-web pages keep the existing host or URL fallback below.
+    }
+    return String(fallbackKey || canonicalPageUrl || '').trim();
+  }
+
   function getCanonicalFaviconHost(url) {
     const pageUrl = getCanonicalPageUrlForFavicon(url);
     if (!pageUrl) {
@@ -995,19 +1009,6 @@
     return isLocalNetworkHost(hostname) || isSuspiciousLocalFaviconHost(hostname);
   }
 
-  // Hosts whose pages serve per-page dynamic favicons (e.g. X serves the
-  // author avatar on tweet/profile pages). Persisting a per-host favicon for
-  // them would leak one page's icon onto every other page of the same host.
-  const DYNAMIC_PAGE_FAVICON_HOSTS = new Set([
-    'x.com',
-    'twitter.com'
-  ]);
-
-  function shouldSkipPersistedFaviconForHost(hostname) {
-    const host = normalizeFaviconHost(hostname);
-    return Boolean(host && DYNAMIC_PAGE_FAVICON_HOSTS.has(host));
-  }
-
   function getFaviconHostPolicy(hostname, options) {
     const config = options || {};
     const shouldBlockHost = typeof config.shouldBlockFaviconForHost === 'function'
@@ -1489,6 +1490,7 @@
     getChromeFaviconUrl,
     getCanonicalFaviconHost,
     getCanonicalPageUrlForFavicon,
+    getFaviconPersistCacheKey,
     getHtmlAttributeValue,
     getKnownThemedFaviconCandidateScores,
     getKnownThemedFaviconCandidateUrls,
@@ -1522,7 +1524,6 @@
     shouldSkipThemeUpgradeCandidate,
     shouldBlockFaviconForHost,
     shouldBlockDirectFaviconHost,
-    shouldAvoidDirectFaviconForHost,
-    shouldSkipPersistedFaviconForHost
+    shouldAvoidDirectFaviconForHost
   });
 });


### PR DESCRIPTION
## 问题

在新标签页中保存某条推文的书签后，该书签会正常显示博主头像，但 **x.com 域下其他条目的图标可能同时变成该头像**（例如 x.com 本身、其他书签和常用站点），且不会自行恢复。

## 根因

favicon 持久化缓存原本按域名生成 key，但图标请求按完整页面 URL 解析。遇到同一域名下不同页面返回不同图标的网站时，一个页面解析出的图标会写入共享的 host 缓存，其他页面随后会读取到错误图标。

这不是 x.com 独有的规则问题，而是缓存粒度与解析粒度不一致。

## 修复方案

将 HTTP(S) 页面的 favicon 持久化缓存统一改为按**规范化完整页面 URL**隔离：

- 缓存 key 包含 origin、path 和 query，区分同域下的不同页面；
- 去除 hash fragment，避免同一文档因页内锚点产生重复缓存；
- 不再维护 `x.com` / `twitter.com` 等动态图标域名白名单；
- 非 HTTP(S) 页面继续使用原有 host 或 URL fallback key；
- 旧的 host 级污染缓存不会被新的页面级 key 命中，因此无需站点专项清理。

这样既解决 X 推文头像污染，也覆盖未来任何同域不同页面图标的站点。

## 改动文件

- `src/shared/favicon-utils.js`：新增通用页面级持久化缓存 key 规则；
- `src/newtab/favicon-view.js`：favicon 读写统一使用页面级 key；
- `scripts/test-favicon-utils.js`：验证 URL 规范化、fragment 去除和非网页 fallback；
- `scripts/test-newtab-favicon-proxy-upgrade.js`：验证同一 host 的不同页面读取不同缓存，且不会读取旧 host 污染项。

## 验证

- `npm test`：通过；
- `npm run check`：通过；
- React：45 个测试文件、231 条测试通过；
- New Tab 本地运行检查：页面正常装载、输入可交互、无 console error/warning；
- 专项回归：同域不同页面 favicon 缓存隔离通过。

## 补充说明

- 命令栏 overlay 不走该持久化缓存路径，无需改动；
- 本修复沿用现有“完整页面图标优先”的设计，将其推广为所有 New Tab favicon 持久化缓存的统一规则。
