### PR TITLE
feat: 实验室新增「单按 Command 显示数字跳转」开关

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -234,6 +234,12 @@
   "settings_pinned_tab_recovery_desc": {
     "message": "Save restorable pinned web tabs and restore missing ones after the browser restarts."
   },
+  "settings_number_shortcut_instant_title": {
+    "message": "Single-press Command to show number jump"
+  },
+  "settings_number_shortcut_instant_desc": {
+    "message": "When enabled, pressing Command/Ctrl once in the command bar or search suggestions immediately shows number jump badges; \"Open in background tab\" no longer uses Command (middle-click still opens in the background)."
+  },
   "document_pip_picker_hint": {
     "message": "Move over the page to choose an element. Click to open PiP, scroll to switch parents, Esc to cancel."
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -234,6 +234,12 @@
   "settings_pinned_tab_recovery_desc": {
     "message": "復元可能な固定タブを記録し、ブラウザ再起動後に自動で戻します。"
   },
+  "settings_number_shortcut_instant_title": {
+    "message": "Command 単押しで数字ジャンプ表示"
+  },
+  "settings_number_shortcut_instant_desc": {
+    "message": "有効にすると、コマンドバーや検索候補で Command/Ctrl を単押しした時点で数字ジャンプバッジが表示されます。「バックグラウンドで開く」は Command に割り当てられなくなります（マウス中クリックは引き続きバックグラウンドで開きます）。"
+  },
   "document_pip_picker_hint": {
     "message": "マウスを動かして要素を選択し、クリックするとWebクリップで表示します。ホイールで親要素へ切り替え、Escでキャンセルできます。"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -234,6 +234,12 @@
   "settings_pinned_tab_recovery_desc": {
     "message": "记录可恢复的置顶网页标签页，在浏览器重启后自动补回"
   },
+  "settings_number_shortcut_instant_title": {
+    "message": "单按 Command 显示数字跳转"
+  },
+  "settings_number_shortcut_instant_desc": {
+    "message": "开启后，命令栏与搜索建议中单按 Command/Ctrl 即显示数字跳转标记；「在后台新开」不再占用 Command（鼠标中键仍可后台打开）"
+  },
   "document_pip_picker_hint": {
     "message": "移动鼠标选择元素，点击打开悬浮窗，滚轮切换父级，Esc 取消。"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -234,6 +234,12 @@
   "settings_pinned_tab_recovery_desc": {
     "message": "記錄可恢復的置頂網頁分頁，瀏覽器重啟後自動補回"
   },
+  "settings_number_shortcut_instant_title": {
+    "message": "單按 Command 顯示數字跳轉"
+  },
+  "settings_number_shortcut_instant_desc": {
+    "message": "開啟後，指令列與搜尋建議中單按 Command/Ctrl 即顯示數字跳轉標記；「在背景新開」不再占用 Command（滑鼠中鍵仍可背景開啟）"
+  },
   "document_pip_picker_hint": {
     "message": "移動滑鼠選擇元素，點擊開啟懸浮窗，滾輪切換父層，Esc 取消。"
   },

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -118,6 +118,8 @@
   const NEWTAB_SEARCH_WIDTH_STORAGE_KEY = '_x_extension_newtab_search_width_2026_unique_';
   const NEWTAB_INPUT_AUTO_FOCUS_ENABLED_STORAGE_KEY = SETTINGS.NEWTAB_INPUT_AUTO_FOCUS_ENABLED_STORAGE_KEY ||
     '_x_extension_newtab_input_auto_focus_enabled_2026_unique_';
+  const NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY = SETTINGS.NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY ||
+    '_x_extension_number_shortcut_instant_enabled_2026_unique_';
   const NEWTAB_TOP_CONTENT_MODE_STORAGE_KEY = SETTINGS.NEWTAB_TOP_CONTENT_MODE_STORAGE_KEY ||
     '_x_extension_newtab_wordmark_visible_2026_unique_';
   const NEWTAB_ZEN_MODE_STORAGE_KEY = '_x_extension_newtab_zen_mode_2026_unique_';
@@ -436,6 +438,7 @@
   let pageNoticeController = null;
   let newtabTopContentMode = 'brand';
   let newtabInputAutoFocusEnabled = false;
+  let numberShortcutInstantEnabled = false;
   let zenModeEnabled = false;
   let bookmarkCurrentPage = 0;
   let bookmarkAllItems = [];
@@ -1249,6 +1252,28 @@
   }
 
   const initialNewtabInputAutoFocusReadyTask = loadNewtabInputAutoFocusEnabled();
+
+  function loadNumberShortcutInstantEnabled() {
+    if (!storageArea) {
+      numberShortcutInstantEnabled = false;
+      return Promise.resolve(numberShortcutInstantEnabled);
+    }
+    return new Promise((resolve) => {
+      storageArea.get([NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY], (result) => {
+        const rawValue = result && result[NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY];
+        numberShortcutInstantEnabled = normalizeNumberShortcutInstantEnabled(rawValue);
+        resolve(numberShortcutInstantEnabled);
+      });
+    });
+  }
+
+  const initialNumberShortcutInstantReadyTask = loadNumberShortcutInstantEnabled();
+
+  function normalizeNumberShortcutInstantEnabled(value) {
+    return typeof SETTINGS.normalizeNumberShortcutInstantEnabled === 'function'
+      ? SETTINGS.normalizeNumberShortcutInstantEnabled(value)
+      : value === true;
+  }
 
   function normalizeBookmarkFolderIconsVisible(value) {
     return typeof SETTINGS.normalizeBookmarkFolderIconsVisible === 'function'
@@ -6214,6 +6239,9 @@
   }
 
   function isBackgroundOpenEvent(event) {
+    if (numberShortcutInstantEnabled) {
+      return isMiddleClick(event);
+    }
     if (typeof NAVIGATION_DISPOSITION.isBackgroundOpenEvent === 'function') {
       return NAVIGATION_DISPOSITION.isBackgroundOpenEvent(event);
     }
@@ -11375,7 +11403,8 @@
         'Release to show numbers'
       ), false, { duration: 0 });
     },
-    onHoldEnd: hideToast
+    onHoldEnd: hideToast,
+    instantActive: () => numberShortcutInstantEnabled
   };
 
   function fallbackCopyText(text) {
@@ -13755,7 +13784,7 @@
     setSuggestionActionModifiersActive(
       Boolean(event && event.altKey),
       Boolean(event && event.shiftKey),
-      Boolean(event && (event.metaKey || event.ctrlKey))
+      Boolean(event && (event.metaKey || event.ctrlKey) && !numberShortcutInstantEnabled)
     );
   }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -3323,6 +3323,24 @@
               <span class="_x_extension_switch_slider_2024_unique_" aria-hidden="true"></span>
             </label>
           </div>
+          <div class="_x_extension_setting_divider_wrap_2024_unique_" role="presentation">
+            <div class="_x_extension_setting_divider_2024_unique_"></div>
+          </div>
+          <div class="_x_extension_setting_row_2024_unique_ _x_extension_setting_row_compact_2024_unique_">
+            <div>
+              <p class="_x_extension_setting_title_2024_unique_">
+                <span class="_x_extension_setting_title_with_icon_2024_unique_">
+                  <span data-i18n="settings_number_shortcut_instant_title">单按 Command 显示数字跳转</span>
+                  <span class="_x_extension_shortcut_badge_2024_unique_ _x_extension_lab_beta_badge_2026_unique_">Beta</span>
+                </span>
+              </p>
+              <p class="_x_extension_setting_desc_2024_unique_" data-i18n="settings_number_shortcut_instant_desc">开启后，命令栏与搜索建议中单按 Command/Ctrl 即显示数字跳转标记；「在后台新开」不再占用 Command（鼠标中键仍可后台打开）</p>
+            </div>
+            <label class="_x_extension_switch_2024_unique_" for="_x_extension_number_shortcut_instant_toggle_2026_unique_">
+              <input id="_x_extension_number_shortcut_instant_toggle_2026_unique_" type="checkbox">
+              <span class="_x_extension_switch_slider_2024_unique_" aria-hidden="true"></span>
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -82,6 +82,7 @@
   const syncImportInput = document.getElementById('_x_extension_sync_import_input_2024_unique_');
   const updateNoticeToggle = document.getElementById('_x_extension_update_notice_toggle_2026_unique_');
   const motionEffectsToggle = document.getElementById('_x_extension_motion_effects_toggle_2026_unique_');
+  const numberShortcutInstantToggle = document.getElementById('_x_extension_number_shortcut_instant_toggle_2026_unique_');
   const fallbackShortcutInput = document.getElementById('_x_extension_shortcuts_input_2024_unique_');
   const fallbackShortcutTokens = document.getElementById('_x_extension_shortcuts_tokens_2024_unique_');
   const fallbackShortcutWrap = document.querySelector('._x_extension_shortcuts_hotkey_wrap_2024_unique_');
@@ -507,6 +508,8 @@
   const UPDATE_NOTICE_ENABLED_STORAGE_KEY = '_x_extension_update_notice_enabled_2026_unique_';
   const MOTION_EFFECTS_ENABLED_STORAGE_KEY = SETTINGS.MOTION_EFFECTS_ENABLED_STORAGE_KEY ||
     '_x_extension_motion_effects_enabled_2026_unique_';
+  const NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY = SETTINGS.NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY ||
+    '_x_extension_number_shortcut_instant_enabled_2026_unique_';
   const AUTO_PIP_ENABLED_STORAGE_KEY = '_x_extension_auto_pip_enabled_2026_unique_';
   const TAB_SWITCHER_ENABLED_STORAGE_KEY = '_x_extension_tab_switcher_enabled_2026_unique_';
   const DOCUMENT_PIP_ENABLED_STORAGE_KEY = '_x_extension_document_pip_enabled_2026_unique_';
@@ -1442,6 +1445,12 @@
     return typeof SETTINGS.normalizeMotionEffectsEnabled === 'function'
       ? SETTINGS.normalizeMotionEffectsEnabled(value)
       : value !== false;
+  }
+
+  function normalizeNumberShortcutInstantEnabled(value) {
+    return typeof SETTINGS.normalizeNumberShortcutInstantEnabled === 'function'
+      ? SETTINGS.normalizeNumberShortcutInstantEnabled(value)
+      : value === true;
   }
 
   function normalizeFaviconEnhancedFetchEnabled(value) {
@@ -4186,6 +4195,16 @@
       storageArea.set({ [MOTION_EFFECTS_ENABLED_STORAGE_KEY]: next });
     });
   }
+  if (numberShortcutInstantToggle) {
+    numberShortcutInstantToggle.addEventListener('change', () => {
+      const next = normalizeNumberShortcutInstantEnabled(numberShortcutInstantToggle.checked);
+      setOptionsToggleState(numberShortcutInstantToggle, next);
+      if (!storageArea) {
+        return;
+      }
+      storageArea.set({ [NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY]: next });
+    });
+  }
   if (autoPipToggle) {
     autoPipToggle.addEventListener('change', () => {
       const next = Boolean(autoPipToggle.checked);
@@ -4804,6 +4823,17 @@
       }
       if (rawValue !== stored) {
         storageArea.set({ [MOTION_EFFECTS_ENABLED_STORAGE_KEY]: stored });
+      }
+      refreshCustomSelects();
+    });
+    storageArea.get([NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY], (result) => {
+      const rawValue = result[NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY];
+      const stored = normalizeNumberShortcutInstantEnabled(rawValue);
+      if (numberShortcutInstantToggle) {
+        setOptionsToggleState(numberShortcutInstantToggle, stored);
+      }
+      if (rawValue !== stored) {
+        storageArea.set({ [NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY]: stored });
       }
       refreshCustomSelects();
     });
@@ -6015,6 +6045,15 @@
       setOptionsToggleState(motionEffectsToggle, next);
       if (raw !== next && storageArea) {
         storageArea.set({ [MOTION_EFFECTS_ENABLED_STORAGE_KEY]: next });
+      }
+      refreshCustomSelects();
+    }
+    if (changes[NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY] && numberShortcutInstantToggle) {
+      const raw = changes[NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY].newValue;
+      const next = normalizeNumberShortcutInstantEnabled(raw);
+      setOptionsToggleState(numberShortcutInstantToggle, next);
+      if (raw !== next && storageArea) {
+        storageArea.set({ [NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY]: next });
       }
       refreshCustomSelects();
     }

--- a/src/overlay/runtime.js
+++ b/src/overlay/runtime.js
@@ -22,6 +22,7 @@
     overlaySizeMode: '_x_extension_overlay_size_mode_2026_unique_',
     overlayEnterAnimation: '_x_extension_overlay_enter_animation_2026_unique_',
     motionEffectsEnabled: '_x_extension_motion_effects_enabled_2026_unique_',
+    numberShortcutInstantEnabled: '_x_extension_number_shortcut_instant_enabled_2026_unique_',
     overlayTabPriority: '_x_extension_overlay_tab_priority_2024_unique_',
     tabRankScoreDebug: '_x_extension_tab_rank_score_debug_2026_unique_'
   });

--- a/src/overlay/search-panel.js
+++ b/src/overlay/search-panel.js
@@ -249,6 +249,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     '_x_extension_overlay_enter_animation_2026_unique_';
   const MOTION_EFFECTS_ENABLED_STORAGE_KEY = overlayStorageKeys.motionEffectsEnabled ||
     '_x_extension_motion_effects_enabled_2026_unique_';
+  const NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY = overlayStorageKeys.numberShortcutInstantEnabled ||
+    '_x_extension_number_shortcut_instant_enabled_2026_unique_';
   const OVERLAY_TAB_PRIORITY_STORAGE_KEY = overlayStorageKeys.overlayTabPriority;
   const TAB_RANK_SCORE_DEBUG_STORAGE_KEY = overlayStorageKeys.tabRankScoreDebug;
   const storageRuntime = overlayRuntime.getStorageArea(chrome);
@@ -300,6 +302,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
   let initialOverlayOpenTabsDefaultVisibleReady = Promise.resolve();
   let documentPipEnabled = Boolean(normalizedOverlayContext.documentPipEnabled);
   let overlayThemeListenerAttached = false;
+  let numberShortcutInstantEnabled = false;
+  let initialNumberShortcutInstantReady = Promise.resolve();
   const initialOverlayEnterAnimationReady = overlayRuntime.getStorageValues(
     storageArea,
     [OVERLAY_ENTER_ANIMATION_STORAGE_KEY]
@@ -317,6 +321,15 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       ? SETTINGS.normalizeMotionEffectsEnabled(result[MOTION_EFFECTS_ENABLED_STORAGE_KEY])
       : result[MOTION_EFFECTS_ENABLED_STORAGE_KEY] !== false;
     return motionEffectsEnabled;
+  });
+  initialNumberShortcutInstantReady = overlayRuntime.getStorageValues(
+    storageArea,
+    [NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY]
+  ).then((result) => {
+    numberShortcutInstantEnabled = typeof SETTINGS.normalizeNumberShortcutInstantEnabled === 'function'
+      ? SETTINGS.normalizeNumberShortcutInstantEnabled(result[NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY])
+      : result[NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY] === true;
+    return numberShortcutInstantEnabled;
   });
 
   function normalizeOverlaySearchBlacklistItems(items) {
@@ -1769,7 +1782,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
           'Release to show numbers'
         ), false, { duration: 0 });
       },
-      onHoldEnd: hideOverlayToast
+      onHoldEnd: hideOverlayToast,
+      instantActive: () => numberShortcutInstantEnabled
     };
 
     function fallbackCopyText(text) {
@@ -4411,7 +4425,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       setSuggestionActionModifiersActive(
         Boolean(event && event.altKey),
         Boolean(event && event.shiftKey),
-        Boolean(event && (event.metaKey || event.ctrlKey))
+        Boolean(event && (event.metaKey || event.ctrlKey) && !numberShortcutInstantEnabled)
       );
     }
 
@@ -4447,7 +4461,10 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
 
     function shouldOpenSearchResultInBackgroundTab(event) {
       const config = {
-        openInBackgroundTab: Boolean(event && (event.metaKey || event.ctrlKey || isMiddleClick(event))),
+        openInBackgroundTab: Boolean(event && (
+          ((event.metaKey || event.ctrlKey) && !numberShortcutInstantEnabled) ||
+          isMiddleClick(event)
+        )),
         openInCurrentTab: Boolean(event && event.altKey)
       };
       if (SUGGESTION_ACTION_MODEL &&
@@ -4475,12 +4492,12 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     }
 
     function getOpenDisposition(event, fallback) {
-      if (typeof NAVIGATION_DISPOSITION.getDisposition === 'function') {
-        return NAVIGATION_DISPOSITION.getDisposition(event, fallback);
+      if (numberShortcutInstantEnabled || typeof NAVIGATION_DISPOSITION.getDisposition !== 'function') {
+        return (isMiddleClick(event) || Boolean(event && (event.metaKey || event.ctrlKey) && !numberShortcutInstantEnabled))
+          ? 'backgroundTab'
+          : (fallback || 'newTab');
       }
-      return isMiddleClick(event) || Boolean(event && (event.metaKey || event.ctrlKey))
-        ? 'backgroundTab'
-        : (fallback || 'newTab');
+      return NAVIGATION_DISPOSITION.getDisposition(event, fallback);
     }
 
     function getSearchResultNewTabDisposition(event) {

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -15,6 +15,7 @@
   const BOOKMARK_FOLDER_ICONS_VISIBLE_STORAGE_KEY = '_x_extension_bookmark_folder_icons_visible_2026_unique_';
   const UPDATE_NOTICE_ENABLED_STORAGE_KEY = '_x_extension_update_notice_enabled_2026_unique_';
   const MOTION_EFFECTS_ENABLED_STORAGE_KEY = '_x_extension_motion_effects_enabled_2026_unique_';
+  const NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY = '_x_extension_number_shortcut_instant_enabled_2026_unique_';
   const FAVICON_ENHANCED_FETCH_ENABLED_STORAGE_KEY = '_x_extension_favicon_enhanced_fetch_enabled_2026_unique_';
   const OVERLAY_OPEN_TABS_DEFAULT_VISIBLE_STORAGE_KEY = '_x_extension_overlay_open_tabs_default_visible_2026_unique_';
   const OVERLAY_ENTER_ANIMATION_STORAGE_KEY = '_x_extension_overlay_enter_animation_2026_unique_';
@@ -193,6 +194,10 @@
 
   function normalizeMotionEffectsEnabled(value) {
     return value !== false;
+  }
+
+  function normalizeNumberShortcutInstantEnabled(value) {
+    return value === true;
   }
 
   function shouldSkipEntryMotion(windowRef, motionEffectsEnabled) {
@@ -383,6 +388,7 @@
     BOOKMARK_FOLDER_ICONS_VISIBLE_STORAGE_KEY,
     UPDATE_NOTICE_ENABLED_STORAGE_KEY,
     MOTION_EFFECTS_ENABLED_STORAGE_KEY,
+    NUMBER_SHORTCUT_INSTANT_ENABLED_STORAGE_KEY,
     FAVICON_ENHANCED_FETCH_ENABLED_STORAGE_KEY,
     OVERLAY_OPEN_TABS_DEFAULT_VISIBLE_STORAGE_KEY,
     OVERLAY_ENTER_ANIMATION_STORAGE_KEY,
@@ -410,6 +416,7 @@
     normalizeBookmarkFolderIconsVisible,
     normalizeUpdateNoticeEnabled,
     normalizeMotionEffectsEnabled,
+    normalizeNumberShortcutInstantEnabled,
     shouldSkipEntryMotion,
     normalizeFaviconEnhancedFetchEnabled,
     normalizeOverlayOpenTabsDefaultVisible,

--- a/src/shared/suggestion-navigation.js
+++ b/src/shared/suggestion-navigation.js
@@ -47,6 +47,13 @@
       : NUMBER_SHORTCUT_HOLD_DURATION_MS;
   }
 
+  function isNumberShortcutInstantActive(options) {
+    const value = options && options.instantActive;
+    return typeof value === 'function'
+      ? Boolean(value())
+      : Boolean(value);
+  }
+
   function getPrimaryModifier(options) {
     const configured = String(options && options.primaryModifier || '').toLowerCase();
     if (configured === 'meta' || configured === 'ctrl') {
@@ -143,13 +150,17 @@
     state.options = options || state.options || {};
     container.setAttribute('data-number-shortcuts-scroll-locked', 'true');
     container.setAttribute('data-number-shortcuts-active', 'true');
-    state.activeTimer = setTimeout(function() {
-      if (numberShortcutStates.get(container) !== state) {
-        return;
-      }
-      numberShortcutStates.delete(container);
-      removeNumberShortcutAttributes(container);
-    }, getNumberShortcutTimeoutMs(state.options));
+    // In instant mode the numbers stay until the user acts (digit / any other
+    // key / Escape / blur), so no auto-dismiss timer is scheduled.
+    if (!isNumberShortcutInstantActive(state.options)) {
+      state.activeTimer = setTimeout(function() {
+        if (numberShortcutStates.get(container) !== state) {
+          return;
+        }
+        numberShortcutStates.delete(container);
+        removeNumberShortcutAttributes(container);
+      }, getNumberShortcutTimeoutMs(state.options));
+    }
     numberShortcutStates.set(container, state);
   }
 
@@ -220,6 +231,11 @@
         clearNumberShortcutState(container, { notifyHoldEnd: false });
         return false;
       }
+      if (state.phase === 'active' && isNumberShortcutInstantActive(state.options)) {
+        // Instant mode: releasing the primary modifier dismisses the numbers.
+        clearNumberShortcutState(container);
+        return false;
+      }
       if (state.phase !== 'armed') {
         return false;
       }
@@ -242,12 +258,16 @@
         clearNumberShortcutState(container);
         return false;
       }
-      if (state && (state.phase === 'holding' || state.phase === 'armed')) {
+      if (state && (state.phase === 'holding' || state.phase === 'armed' || state.phase === 'active')) {
         return false;
       }
       clearNumberShortcutState(container);
       if (!event.repeat) {
-        beginNumberShortcutHold(container, options, primaryModifier);
+        if (isNumberShortcutInstantActive(options)) {
+          enterNumberShortcutsActive(container, options);
+        } else {
+          beginNumberShortcutHold(container, options, primaryModifier);
+        }
       }
       return false;
     }
@@ -266,8 +286,12 @@
       consumeNumberShortcutEvent(event);
       return true;
     }
-    const plainNumber = !event.metaKey && !event.ctrlKey &&
-      !event.altKey && !event.shiftKey && /^[0-9]$/.test(key);
+    // In instant mode the digit is pressed while the primary modifier is still
+    // held, so the modifier keys are allowed there; otherwise digits must be plain.
+    const instantActive = isNumberShortcutInstantActive(state.options);
+    const plainNumber = /^[0-9]$/.test(key) && (instantActive
+      ? !event.altKey && !event.shiftKey
+      : !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey);
     if (!plainNumber) {
       cancelNumberShortcuts(container);
       return false;


### PR DESCRIPTION
## 功能

在「设置 → 实验室功能」新增开关 **「单按 Command 显示数字跳转」**（默认关闭，老用户行为不变）。

开启后：

- **按下 Command/Ctrl 立即显示数字跳转标记**（无需长按 0.4 秒再松开）；
- **按住 Command/Ctrl 的同时按数字键**（0-9）→ 直接跳转到对应序号的结果；
- **松开 Command/Ctrl** → 数字标记立即消失，不再一直挂着；
- 「在后台新开」不再占用 Command/Ctrl（**鼠标中键仍可后台打开**）；Shift / Alt 的原有语义不变。

开关关闭时，原有行为（长按 0.4 秒松开显示数字、Command+回车后台打开）完全不变。

## 实现说明

- `src/shared/suggestion-navigation.js`：数字快捷键状态机支持 `instantActive` 模式——主修饰键按下即进入激活、松开即清除、数字键允许在按住修饰键时触发；instant 模式下不挂自动消失定时器
- `src/shared/settings.js` / `src/overlay/runtime.js`：新增存储 key 与规范化函数
- `src/overlay/search-panel.js`、`src/newtab/newtab.js`：读取开关；instant 模式下 Command/Ctrl 不再触发「在后台新开」（提示、回车、点击三处均已拦截，中键保留）
- `src/options/options.html` / `options.js`：实验室 tab 新增开关（Beta 徽标），读/写/跨页面同步齐全
- `_locales`：简体中文 / 繁体中文 / English / 日本語 四语文案

## 验证

- `check:js`（87 文件）/ `check:manifest` / `check:bookmarks` / `audit:i18n` 全部通过
- 数字快捷键状态机功能单测 11/11（instant 按下即出、按住按数字跳转、松手消失；默认长按流程不变）
- 全量 node 测试通过（除 2 个依赖 `jsdom` 的环境性失败，与本次改动无关）
