### PR TITLE
Harden search and overlay behavior

### DIFF
--- a/scripts/test-background-search-suggestions.js
+++ b/scripts/test-background-search-suggestions.js
@@ -114,6 +114,13 @@ function createChromeStub(options) {
       visitCount: 2,
       typedCount: 0,
       lastVisitTime: now - 7000
+    },
+    {
+      title: 'Home - 0HTTP',
+      url: 'https://code.0http.com/',
+      visitCount: 2,
+      typedCount: 0,
+      lastVisitTime: now - 8000
     }
   ].concat(
     Array.from({ length: 260 }, (_, index) => ({
@@ -132,7 +139,11 @@ function createChromeStub(options) {
     }]
   );
   const topSiteItems = [
-    { title: 'GitHub', url: 'https://github.com/' }
+    { title: 'GitHub', url: 'https://github.com/' },
+    {
+      title: 'Lumno | 浏览器命令栏、聚焦搜索与极简新标签页',
+      url: 'http://127.0.0.1:4321/'
+    }
   ];
 
   const chromeApi = {
@@ -575,6 +586,18 @@ async function run() {
     Array.from(multiTermSuggestions, (item) => item && item.url),
     ['https://example.com/codex-favorite'],
     'background search should require every query term instead of backfilling history that only matches one term'
+  );
+
+  const dottedNavigationSuggestions = await context.__testGetSearchSuggestions('code.0', {
+    includeOpenTabs: false
+  });
+  assert.ok(
+    dottedNavigationSuggestions.some((item) => item && item.url === 'https://code.0http.com/'),
+    'dotted navigation queries should retain the history result whose host matches the full input'
+  );
+  assert.ok(
+    !dottedNavigationSuggestions.some((item) => item && item.url === 'http://127.0.0.1:4321/'),
+    'dotted navigation queries should exclude top sites that match only one token from the input'
   );
 
   const noMatchSuggestions = await context.__testGetSearchSuggestions('definitely-no-local-match-xyz');

--- a/scripts/test-direct-navigation-settle.js
+++ b/scripts/test-direct-navigation-settle.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const path = require('path');
+
+const {
+  createDirectNavigationSettleController
+} = require(path.join('..', 'src', 'newtab', 'direct-navigation-settle.js'));
+
+let nextTimerId = 1;
+const timers = new Map();
+const clearedTimerIds = [];
+const settledContexts = [];
+const controller = createDirectNavigationSettleController({
+  delayMs: 120,
+  setTimeout(callback, delayMs) {
+    const timerId = nextTimerId;
+    nextTimerId += 1;
+    timers.set(timerId, { callback, delayMs });
+    return timerId;
+  },
+  clearTimeout(timerId) {
+    clearedTimerIds.push(timerId);
+    timers.delete(timerId);
+  },
+  onSettle(context) {
+    settledContexts.push(context);
+  }
+});
+
+controller.schedule({ query: 'first.example', requestSeq: 1 });
+assert.strictEqual(controller.isPending(), true);
+assert.strictEqual(timers.get(1).delayMs, 120);
+
+controller.schedule({ query: 'second.example', requestSeq: 2 });
+assert.deepStrictEqual(clearedTimerIds, [1], 'a newer request should cancel the previous settle timer');
+assert.strictEqual(timers.has(1), false);
+assert.strictEqual(timers.has(2), true);
+
+timers.get(2).callback();
+assert.strictEqual(controller.isPending(), false);
+assert.deepStrictEqual(
+  settledContexts,
+  [{ query: 'second.example', requestSeq: 2 }],
+  'only the latest request context should settle'
+);
+assert.strictEqual(controller.cancel(), false, 'cancelling an idle controller should be a no-op');
+
+controller.schedule({ query: 'cancelled.example', requestSeq: 3 });
+assert.strictEqual(controller.cancel(), true);
+assert.strictEqual(controller.isPending(), false);
+assert.strictEqual(timers.has(3), false);
+
+console.log('direct navigation settle controller tests passed');

--- a/scripts/test-overlay-page-theme-adaptation-setting.js
+++ b/scripts/test-overlay-page-theme-adaptation-setting.js
@@ -81,6 +81,11 @@ assert.match(
 );
 assert.match(
   overlaySource,
+  /typeof overlayPageTheme\.getCssColorThemeSignal === 'function'[\s\S]*?return overlayPageTheme\.getCssColorThemeSignal\(color, weight\);/,
+  'page background signals should preserve CSS alpha instead of treating transparent black as opaque black'
+);
+assert.match(
+  overlaySource,
   /!changes\[THEME_STORAGE_KEY\][\s\S]*?!changes\[OVERLAY_PAGE_THEME_ADAPTATION_ENABLED_STORAGE_KEY\][\s\S]*?applyOverlayTheme\(nextMode\)/,
   'an open overlay should update immediately when either theme preference changes'
 );
@@ -94,6 +99,58 @@ const cases = [
 ];
 cases.forEach(([input, expected]) => {
   assert.strictEqual(pageTheme.resolveOverlayTheme(input), expected);
+});
+
+const backgroundCases = [
+  [{ resolvedTheme: 'dark', pageTheme: 'light' }, true],
+  [{ resolvedTheme: 'dark', pageTheme: 'dark' }, false],
+  [{ resolvedTheme: 'dark', pageTheme: null }, false],
+  [{ resolvedTheme: 'light', pageTheme: 'dark' }, false]
+];
+backgroundCases.forEach(([input, expected]) => {
+  assert.strictEqual(pageTheme.shouldStrengthenDarkOverlayBackground(input), expected);
+});
+assert.match(
+  overlaySource,
+  /dark:\s*\{[\s\S]*?bg: 'rgba\(20, 20, 20, 0\.62\)'[\s\S]*?lightPageBg: 'rgba\(20, 20, 20, 0\.82\)'/,
+  'dark mode should expose a stronger background only for light webpages'
+);
+assert.match(
+  overlaySource,
+  /const pageTheme = detectPageTheme\(\);[\s\S]*?resolveOverlayTheme\(mode, pageTheme\)[\s\S]*?shouldStrengthenDarkOverlayBackground\([\s\S]*?resolvedTheme: resolved,[\s\S]*?pageTheme/,
+  'overlay rendering should keep detecting the webpage theme even when the user forces dark mode'
+);
+assert.match(
+  overlaySource,
+  /const applyOverlayTheme = \(mode\) => \{[\s\S]*?syncOverlayPageThemeObservation\(\);/,
+  'theme application should synchronize page-theme observation through the shared policy'
+);
+const applyOverlayThemeSource = overlaySource.slice(
+  overlaySource.indexOf('const applyOverlayTheme = (mode) => {'),
+  overlaySource.indexOf('// 使用系统字体')
+);
+assert.doesNotMatch(
+  applyOverlayThemeSource,
+  /stopOverlayPageThemeObserver\(\)/,
+  'explicit themes should not unconditionally tear down observation after policy synchronization'
+);
+
+const observationCases = [
+  [{ mode: 'dark', pageThemeAdaptationEnabled: false, systemTheme: 'light' }, true],
+  [{ mode: 'light', pageThemeAdaptationEnabled: true, systemTheme: 'dark' }, false],
+  [{ mode: 'system', pageThemeAdaptationEnabled: true, systemTheme: 'light' }, true],
+  [{ mode: 'system', pageThemeAdaptationEnabled: false, systemTheme: 'dark' }, true],
+  [{ mode: 'system', pageThemeAdaptationEnabled: false, systemTheme: 'light' }, false]
+];
+observationCases.forEach(([input, expected]) => {
+  const events = [];
+  const actual = pageTheme.syncPageThemeObservation({
+    ...input,
+    start: () => events.push('start'),
+    stop: () => events.push('stop')
+  });
+  assert.strictEqual(actual, expected);
+  assert.deepStrictEqual(events, [expected ? 'start' : 'stop']);
 });
 
 const expectedCopy = {

--- a/scripts/test-overlay-page-theme.js
+++ b/scripts/test-overlay-page-theme.js
@@ -169,6 +169,35 @@ function testVisualThemeSamplesOverlayFootprint() {
   );
 }
 
+function testTransparentCssColorsDoNotBecomeDarkThemeSignals() {
+  assert.strictEqual(
+    pageTheme.getCssColorThemeSignal('rgba(0, 0, 0, 0)', 0.78),
+    null,
+    'a fully transparent root background should not count as a black page surface'
+  );
+  assert.strictEqual(
+    pageTheme.getCssColorThemeSignal('rgba(0, 0, 0, 0.1)', 0.78).theme,
+    'light',
+    'a faint translucent black surface should be composited over the page canvas before classification'
+  );
+}
+
+function testWappalyzerLikeLightPageSignalsResolveLight() {
+  const signals = [
+    { theme: 'light', confidence: 0.74, weight: 0.48 },
+    { theme: 'light', confidence: 0.62, weight: 0.26 },
+    pageTheme.getCssColorThemeSignal('#4608ad', 0.72),
+    pageTheme.getCssColorThemeSignal('rgba(0, 0, 0, 0)', 0.78),
+    pageTheme.getCssColorThemeSignal('rgba(0, 0, 0, 0)', 0.58),
+    { theme: 'light', confidence: 0.62, weight: 1.05 }
+  ];
+  assert.strictEqual(
+    pageTheme.resolvePageThemeSignals(signals),
+    'light',
+    'explicit light mode and a mostly light viewport should beat a dark brand theme-color'
+  );
+}
+
 function testSearchPanelFusesThemeColorAndVisualSignals() {
   const searchPanelSource = fs.readFileSync(path.join(__dirname, '../src/overlay/search-panel.js'), 'utf8');
   const themeColorSignalIndex = searchPanelSource.indexOf('getThemeSignalFromRgb(themeColorRgb');
@@ -314,6 +343,8 @@ testVisualThemeReturnsNullForAmbiguousSurfaces();
 testVisualThemeUsesLightTextWhenBackgroundIsTransparent();
 testVisualThemeIgnoresLumnoOverlayElements();
 testVisualThemeSamplesOverlayFootprint();
+testTransparentCssColorsDoNotBecomeDarkThemeSignals();
+testWappalyzerLikeLightPageSignalsResolveLight();
 testSearchPanelFusesThemeColorAndVisualSignals();
 testSearchPanelDoesNotShortCircuitExplicitThemeHints();
 testSearchPanelAvoidsBusinessClassNameThemeMatches();

--- a/scripts/test-search-result-display-limit-setting.js
+++ b/scripts/test-search-result-display-limit-setting.js
@@ -8,6 +8,8 @@ const optionsSource = read('src/options/options.js');
 const newtabSource = read('src/newtab/newtab.js');
 const overlaySource = read('src/overlay/search-panel.js');
 const overlayRuntimeSource = read('src/overlay/runtime.js');
+const overlaySuggestionsStyles = read('src/overlay/suggestions-view.css');
+const suggestionNavigation = require('../src/shared/suggestion-navigation.js');
 
 const sourcesIndex = optionsHtml.indexOf('data-i18n="settings_search_result_sources_title"');
 const displayLimitIndex = optionsHtml.indexOf('data-i18n="settings_search_result_display_limit_title"');
@@ -48,18 +50,67 @@ assert.match(newtabSource,
 assert.match(overlaySource,
   /changes\[SEARCH_RESULT_DISPLAY_LIMIT_STORAGE_KEY\][\s\S]*?refreshOverlaySuggestionsFromLastResponse\(\)/,
   'overlay should re-render current results when the limit changes');
-assert.match(overlaySource,
+assert.doesNotMatch(overlaySource,
   /function limitOverlayTabsForDisplay\(list\)[\s\S]*?slice\(0, normalizeSearchResultDisplayLimit\(overlaySearchResultDisplayLimit\)\)/,
-  'overlay should apply the configured result limit to opened-tab results');
+  'overlay should not truncate opened-tab results before rendering');
+assert.match(overlaySource,
+  /function setOpenTabsResultsViewport\(active, itemCount\)[\s\S]*?getComputedStyle\(suggestionsContainer\)[\s\S]*?getVisibleRowsViewportHeight\([\s\S]*?--x-ov-suggestion-row-height[\s\S]*?--x-ov-suggestion-row-gap/,
+  'overlay should derive the opened-tab viewport from the rendered CSS row tokens');
+assert.match(overlaySuggestionsStyles,
+  /\.x-ov-suggestions-container\[data-open-tabs-visible-row-limit\] \{[\s\S]*?scrollbar-width:\s*thin;[\s\S]*?scrollbar-color:/,
+  'the scrollable opened-tab viewport should restore its visible scrollbar');
+assert.match(overlaySuggestionsStyles,
+  /\.x-ov-suggestions-container\[data-open-tabs-visible-row-limit\]::\-webkit-scrollbar-thumb \{[\s\S]*?border-radius:\s*999px;[\s\S]*?background-color:/,
+  'Chromium should render the opened-tab scrollbar thumb');
 assert.match(overlaySource,
   /changes\[SEARCH_RESULT_DISPLAY_LIMIT_STORAGE_KEY\][\s\S]*?openTabsSearchModeActive[\s\S]*?shouldShowOpenTabsForEmptyQuery\(\)[\s\S]*?renderTabSuggestions\(filterTabsForOverlay\(tabs, latestOverlayQuery\)\)/,
   'overlay should immediately re-render visible opened tabs when the limit changes');
 assert.match(overlaySource,
-  /function renderTabSuggestions\(tabList\)[\s\S]*?const list = limitOverlayTabsForDisplay\(tabList\);/,
-  'both default and searched opened-tab lists should use the configured result limit');
+  /function renderTabSuggestions\(tabList\)[\s\S]*?const list = Array\.isArray\(tabList\) \? tabList\.slice\(\) : \[\];[\s\S]*?setOpenTabsResultsViewport\(true, list\.length\);[\s\S]*?reactView\.renderTabs\(list\);/,
+  'both default and searched opened-tab lists should render in full inside the capped viewport');
+assert.match(overlaySource,
+  /allSuggestions = limitOverlaySuggestionsForDisplay\(allSuggestions,[\s\S]*?setOpenTabsResultsViewport\(false\);[\s\S]*?reactView\.render\(\{/,
+  'ordinary search results should clear the opened-tab viewport override and remain data-limited');
 assert.match(overlaySource,
   /function filterTabsForOverlay\(tabList, queryText\) \{\s*const list = Array\.isArray\(tabList\) \? tabList : \[\];/,
   'opened-tab matching should search the complete tab list before display limiting');
+
+assert.strictEqual(
+  suggestionNavigation.getVisibleRowsViewportHeight({
+    visibleRowLimit: 5,
+    itemCount: 10,
+    rowHeight: 52,
+    rowGap: 4,
+    paddingTop: 12,
+    paddingBottom: 12
+  }),
+  304,
+  'a scrollable viewport should include the gap after the last visible row'
+);
+assert.strictEqual(
+  suggestionNavigation.getVisibleRowsViewportHeight({
+    visibleRowLimit: 5,
+    itemCount: 5,
+    rowHeight: 52,
+    rowGap: 4,
+    paddingTop: 12,
+    paddingBottom: 12
+  }),
+  300,
+  'a complete five-row list should not reserve a trailing row gap'
+);
+assert.strictEqual(
+  suggestionNavigation.getVisibleRowsViewportHeight({
+    visibleRowLimit: 5,
+    itemCount: 0,
+    rowHeight: 52,
+    rowGap: 4,
+    paddingTop: 12,
+    paddingBottom: 12
+  }),
+  0,
+  'an empty list should not force a viewport height'
+);
 
 ['en', 'ja', 'zh_CN', 'zh_TW'].forEach((locale) => {
   const messages = JSON.parse(read(`_locales/${locale}/messages.json`));

--- a/scripts/test-suggestion-render-stability.js
+++ b/scripts/test-suggestion-render-stability.js
@@ -122,6 +122,7 @@ function verifyClassification() {
 
 verifyClassification();
 const newtabSource = readSource('src/newtab/newtab.js');
+const newtabHtml = readSource('src/newtab/newtab.html');
 const newtabLayoutSource = readSource('src/newtab/layout.js');
 const overlaySource = readSource('src/overlay/search-panel.js');
 
@@ -149,9 +150,34 @@ assert.match(
   'Overlay should run its height pipeline only for append or structure updates'
 );
 assert.match(
+  newtabHtml,
+  /<script src="direct-navigation-settle\.js"><\/script>/,
+  'New Tab should load the direct-navigation settle controller before its page runtime'
+);
+assert.match(
   newtabSource,
-  /if \(isPaste \|\| getDirectUrlSuggestion\(query\)\) \{[\s\S]*?renderPendingSuggestions\(query\);[\s\S]*?requestSuggestions\(query, \{ immediate: true \}\);/,
-  'New Tab should retain the previous result rows while a direct URL request is pending'
+  /const directUrlSuggestion = getDirectUrlSuggestion\(query\);[\s\S]*?hasCachedOpenTabMatch[\s\S]*?renderPendingSuggestions\(query\);[\s\S]*?deferInitialDirectNavigationRender: Boolean\([\s\S]*?directUrlSuggestion && !hasCachedOpenTabMatch/,
+  'New Tab should render cached open-tab matches immediately and defer only unresolved direct-navigation placeholders'
+);
+assert.match(
+  newtabSource,
+  /createDirectNavigationSettleController\(\{[\s\S]*?delayMs: DIRECT_NAVIGATION_SETTLE_DELAY_MS,[\s\S]*?onSettle: \(\{ query, requestSeq \}\)[\s\S]*?renderPendingSuggestions\(query\);/,
+  'New Tab should delegate settle timer ownership to the tested controller'
+);
+assert.match(
+  newtabSource,
+  /function requestSuggestions\(query, options\)[\s\S]*?directNavigationSettleController\.schedule\(\{[\s\S]*?query: requestQuery,[\s\S]*?requestSeq[\s\S]*?directNavigationSettleController\.cancel\(\);[\s\S]*?renderSuggestions\(localSuggestions, requestQuery\);/,
+  'New Tab should cancel the provisional direct URL render when the local result arrives in time'
+);
+assert.match(
+  newtabSource,
+  /function getDirectUrlSuggestion\(input\)[\s\S]*?getMatchedOpenTabForSuggestion\(suggestion\)[\s\S]*?_xMatchedTabId: matchedTab\.id/,
+  'New Tab should build a cached open-tab URL result with its final title and switch identity'
+);
+assert.match(
+  newtabSource,
+  /refreshTabsForSearchContext\(\(\) => \{\}\);[\s\S]*?function resolveQuickNavigation/,
+  'New Tab should warm its open-tab snapshot before the first URL input'
 );
 assert.match(
   overlaySource,

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -9219,7 +9219,8 @@ async function getSearchSuggestions(query, options) {
       upsertSuggestion(item, 'history');
     });
 
-    (Array.isArray(topSites) ? topSites : []).forEach((site) => {
+    const topSiteMatches = collectSearchMatches(topSites);
+    topSiteMatches.forEach((site) => {
       if (!site || !site.url || isUrlBlockedBySearchBlacklist(site.url, searchBlacklistItems)) {
         return;
       }

--- a/src/newtab/direct-navigation-settle.js
+++ b/src/newtab/direct-navigation-settle.js
@@ -1,0 +1,50 @@
+(function(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  root.LumnoNewtabDirectNavigationSettle = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  function createDirectNavigationSettleController(options) {
+    const config = options && typeof options === 'object' ? options : {};
+    const scheduleTimer = typeof config.setTimeout === 'function'
+      ? config.setTimeout
+      : setTimeout;
+    const cancelTimer = typeof config.clearTimeout === 'function'
+      ? config.clearTimeout
+      : clearTimeout;
+    const delayMs = Number.isFinite(Number(config.delayMs))
+      ? Math.max(0, Number(config.delayMs))
+      : 120;
+    let timer = null;
+
+    function cancel() {
+      if (timer === null) {
+        return false;
+      }
+      cancelTimer(timer);
+      timer = null;
+      return true;
+    }
+
+    function schedule(context) {
+      cancel();
+      timer = scheduleTimer(() => {
+        timer = null;
+        if (typeof config.onSettle === 'function') {
+          config.onSettle(context);
+        }
+      }, delayMs);
+    }
+
+    return Object.freeze({
+      cancel,
+      schedule,
+      isPending: () => timer !== null
+    });
+  }
+
+  return Object.freeze({
+    createDirectNavigationSettleController
+  });
+});

--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -6562,6 +6562,7 @@
     <script src="bookmark-move-history.js"></script>
     <script src="bookmark-drag.js"></script>
     <script src="layout.js"></script>
+    <script src="direct-navigation-settle.js"></script>
     <script src="background-search-focus.js"></script>
     <script src="bookmark-cascade-position.js"></script>
     <script src="bookmark-cascade-menu.js"></script>

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -194,6 +194,7 @@
   const NEWTAB_TOAST = globalThis.LumnoNewtabToast || {};
   const NEWTAB_LAYOUT = globalThis.LumnoNewtabLayout || {};
   const NEWTAB_DOCK = globalThis.LumnoNewtabDock || {};
+  const NEWTAB_DIRECT_NAVIGATION_SETTLE = globalThis.LumnoNewtabDirectNavigationSettle || {};
   const NEWTAB_BACKGROUND_SEARCH_FOCUS = globalThis.LumnoNewtabBackgroundSearchFocus || {};
   const NEWTAB_RECENT_VIEW = globalThis.LumnoNewtabRecentSitesView || {};
   const NEWTAB_BOOKMARKS_VIEW = globalThis.LumnoNewtabBookmarksView || {};
@@ -247,6 +248,7 @@
       typeof NEWTAB_LAYOUT.getAdaptiveGridColumnCount !== 'function' ||
       typeof NEWTAB_LAYOUT.getGridContentWidthForColumns !== 'function' ||
       typeof NEWTAB_DOCK.createBottomDockRuntime !== 'function' ||
+      typeof NEWTAB_DIRECT_NAVIGATION_SETTLE.createDirectNavigationSettleController !== 'function' ||
       typeof NEWTAB_BACKGROUND_SEARCH_FOCUS.createBackgroundFocusHandler !== 'function' ||
       typeof NEWTAB_RECENT_VIEW.createRecentSitesView !== 'function' ||
       typeof NEWTAB_BOOKMARKS_VIEW.createBookmarksView !== 'function' ||
@@ -13644,11 +13646,21 @@
     if (!targetUrl) {
       return null;
     }
-    return {
+    const suggestion = {
       type: 'directUrl',
       title: formatMessage('open_url', '打开 {url}', { url: targetUrl }),
       url: targetUrl,
       favicon: getPageFaviconCandidateUrl(targetUrl)
+    };
+    const matchedTab = getMatchedOpenTabForSuggestion(suggestion);
+    if (!matchedTab) {
+      return suggestion;
+    }
+    return {
+      ...suggestion,
+      title: String(matchedTab.title || '').trim() || suggestion.title,
+      favicon: String(matchedTab.favIconUrl || '').trim() || suggestion.favicon,
+      _xMatchedTabId: matchedTab.id
     };
   }
 
@@ -13685,7 +13697,7 @@
     }
   }
 
-  function getMatchedOpenTabIdForSuggestion(suggestion) {
+  function getMatchedOpenTabForSuggestion(suggestion) {
     if (!suggestion || !suggestion.url || !Array.isArray(tabs) || tabs.length === 0) {
       return null;
     }
@@ -13700,10 +13712,15 @@
       }
       const current = normalizeTabMatchUrl(tab.url);
       if (current && current === target) {
-        return tab.id;
+        return tab;
       }
     }
     return null;
+  }
+
+  function getMatchedOpenTabIdForSuggestion(suggestion) {
+    const matchedTab = getMatchedOpenTabForSuggestion(suggestion);
+    return matchedTab ? matchedTab.id : null;
   }
 
   function shouldSwitchMatchedTabSuggestion(suggestion, index) {
@@ -13819,6 +13836,10 @@
       finish(true);
     });
   }
+
+  // Warm the tab snapshot before the first URL input so a matched page can render
+  // with its final title and switch action on the first visible frame.
+  refreshTabsForSearchContext(() => {});
 
   function resolveQuickNavigation(query) {
     const directUrlSuggestion = getDirectUrlSuggestion(query);
@@ -14068,11 +14089,13 @@
 
   function refreshTabsIfIdle() {
     if (!latestQuery || !latestQuery.trim()) {
+      refreshTabsForSearchContext(() => {});
       clearSearchSuggestions();
     }
   }
 
   function clearSearchSuggestions() {
+    directNavigationSettleController.cancel();
     searchModeResultTransitionQuery = '';
     if (layoutController &&
         typeof layoutController.finishSuggestionsInputSession === 'function') {
@@ -14488,6 +14511,18 @@
     renderSuggestions(lastSuggestionResponse, query, options);
   }
 
+  const DIRECT_NAVIGATION_SETTLE_DELAY_MS = 120;
+  const directNavigationSettleController =
+    NEWTAB_DIRECT_NAVIGATION_SETTLE.createDirectNavigationSettleController({
+      delayMs: DIRECT_NAVIGATION_SETTLE_DELAY_MS,
+      onSettle: ({ query, requestSeq }) => {
+        if (requestSeq !== suggestionRequestSeq || query !== latestQuery) {
+          return;
+        }
+        renderPendingSuggestions(query);
+      }
+    });
+
   function requestSuggestions(query, options) {
     latestQuery = query;
     const requestLocalSearchScope = localSearchScopeState;
@@ -14496,10 +14531,20 @@
       return;
     }
     const immediate = options && options.immediate;
+    const deferInitialDirectNavigationRender = Boolean(
+      options && options.deferInitialDirectNavigationRender
+    );
     const retryCount = options && Number(options.retryCount) > 0 ? Number(options.retryCount) : 0;
     const requestStartedAt = Date.now();
     const requestQuery = latestQuery;
     const requestSeq = ++suggestionRequestSeq;
+    directNavigationSettleController.cancel();
+    if (deferInitialDirectNavigationRender) {
+      directNavigationSettleController.schedule({
+        query: requestQuery,
+        requestSeq
+      });
+    }
     const waitForRemoteMixHeight = Boolean(
       !requestLocalSearchScope && !siteSearchState && layoutController &&
       typeof layoutController.beginSuggestionsInputSession === 'function'
@@ -14541,6 +14586,7 @@
       if (requestSeq !== suggestionRequestSeq || requestQuery !== latestQuery) {
         return;
       }
+      directNavigationSettleController.cancel();
       if (chrome.runtime && chrome.runtime.lastError) {
         renderPendingSuggestions(requestQuery, {
           settleHeightAfterRemoteMix: waitForRemoteMixHeight
@@ -14600,6 +14646,7 @@
         suggestionRequestWatchdogTimer = null;
       }
       if (requestSeq === suggestionRequestSeq && requestQuery === latestQuery) {
+        directNavigationSettleController.cancel();
         renderPendingSuggestions(requestQuery, {
           settleHeightAfterRemoteMix: waitForRemoteMixHeight
         });
@@ -14709,10 +14756,22 @@
         renderSuggestions([], query);
         return;
       }
-      if (isPaste || getDirectUrlSuggestion(query)) {
+      const directUrlSuggestion = getDirectUrlSuggestion(query);
+      const hasCachedOpenTabMatch = Boolean(
+        directUrlSuggestion &&
+        typeof directUrlSuggestion._xMatchedTabId === 'number'
+      );
+      if (isPaste || directUrlSuggestion) {
         latestQuery = query;
-        renderPendingSuggestions(query);
-        requestSuggestions(query, { immediate: true });
+        if (!directUrlSuggestion || hasCachedOpenTabMatch) {
+          renderPendingSuggestions(query);
+        }
+        requestSuggestions(query, {
+          immediate: true,
+          deferInitialDirectNavigationRender: Boolean(
+            directUrlSuggestion && !hasCachedOpenTabMatch
+          )
+        });
         return;
       }
       requestSuggestions(query);
@@ -15926,6 +15985,7 @@
 
   inputParts.input.addEventListener('compositionstart', function(event) {
     suggestionRequestSeq += 1;
+    directNavigationSettleController.cancel();
     if (remoteSuggestionDebounceTimer) {
       clearTimeout(remoteSuggestionDebounceTimer);
       remoteSuggestionDebounceTimer = null;
@@ -15957,9 +16017,17 @@
         typeof layoutController.beginSuggestionsInputSession === 'function') {
       layoutController.beginSuggestionsInputSession();
     }
-    if (getDirectUrlSuggestion(query)) {
-      renderPendingSuggestions(query);
-      requestSuggestions(query, { immediate: true });
+    const directUrlSuggestion = getDirectUrlSuggestion(query);
+    if (directUrlSuggestion) {
+      const hasCachedOpenTabMatch =
+        typeof directUrlSuggestion._xMatchedTabId === 'number';
+      if (hasCachedOpenTabMatch) {
+        renderPendingSuggestions(query);
+      }
+      requestSuggestions(query, {
+        immediate: true,
+        deferInitialDirectNavigationRender: !hasCachedOpenTabMatch
+      });
       return;
     }
     requestSuggestions(query);

--- a/src/overlay/page-theme.js
+++ b/src/overlay/page-theme.js
@@ -177,6 +177,66 @@
     ) / 255;
   }
 
+  function getCssColorThemeSignal(color, weight) {
+    const parsed = parseCssColor(color);
+    if (!parsed || parsed.alpha <= 0.08) {
+      return null;
+    }
+    const rgb = parsed.alpha < 1
+      ? mixRgb(parsed.rgb, DEFAULT_CANVAS_RGB, parsed.alpha)
+      : parsed.rgb;
+    const luminance = getRelativeLuminance(rgb);
+    const normalizedWeight = Number.isFinite(Number(weight))
+      ? Math.max(0, Number(weight))
+      : 1;
+    if (luminance < 0.42) {
+      return {
+        theme: 'dark',
+        confidence: clampNumber((0.42 - luminance) / 0.42, 0, 1),
+        weight: normalizedWeight
+      };
+    }
+    if (luminance > 0.58) {
+      return {
+        theme: 'light',
+        confidence: clampNumber((luminance - 0.58) / 0.42, 0, 1),
+        weight: normalizedWeight
+      };
+    }
+    return null;
+  }
+
+  function resolvePageThemeSignals(signals) {
+    let totalScore = 0;
+    let totalWeight = 0;
+    (Array.isArray(signals) ? signals : []).forEach((signal) => {
+      if (!signal || (signal.theme !== 'dark' && signal.theme !== 'light')) {
+        return;
+      }
+      const confidence = clampNumber(signal.confidence, 0, 1);
+      const weight = Number.isFinite(Number(signal.weight))
+        ? Math.max(0, Number(signal.weight))
+        : 1;
+      if (confidence <= 0 || weight <= 0) {
+        return;
+      }
+      const contributionWeight = confidence * weight;
+      totalScore += (signal.theme === 'dark' ? -1 : 1) * contributionWeight;
+      totalWeight += contributionWeight;
+    });
+    if (totalWeight <= 0.2) {
+      return null;
+    }
+    const confidence = totalScore / totalWeight;
+    if (confidence <= -0.22) {
+      return 'dark';
+    }
+    if (confidence >= 0.22) {
+      return 'light';
+    }
+    return null;
+  }
+
   function getComputedStyleFor(win, element) {
     if (!win || typeof win.getComputedStyle !== 'function' || !element) {
       return null;
@@ -422,12 +482,46 @@
     return settings.systemTheme === 'dark' ? 'dark' : 'light';
   }
 
+  function shouldStrengthenDarkOverlayBackground(options) {
+    const settings = options && typeof options === 'object' ? options : {};
+    return settings.resolvedTheme === 'dark' && settings.pageTheme === 'light';
+  }
+
+  function shouldObservePageTheme(options) {
+    const settings = options && typeof options === 'object' ? options : {};
+    const mode = settings.mode === 'dark' || settings.mode === 'light'
+      ? settings.mode
+      : 'system';
+    if (mode === 'dark') {
+      return true;
+    }
+    if (mode !== 'system') {
+      return false;
+    }
+    return settings.pageThemeAdaptationEnabled === true || settings.systemTheme === 'dark';
+  }
+
+  function syncPageThemeObservation(options) {
+    const settings = options && typeof options === 'object' ? options : {};
+    const shouldObserve = shouldObservePageTheme(settings);
+    const callback = shouldObserve ? settings.start : settings.stop;
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return shouldObserve;
+  }
+
   return Object.freeze({
     parseCssColor,
     getRelativeLuminance,
     getPerceptualTone,
+    getCssColorThemeSignal,
+    resolvePageThemeSignals,
     detectPageVisualThemeSignal,
     detectPageVisualTheme,
-    resolveOverlayTheme
+    resolveOverlayTheme,
+    shouldStrengthenDarkOverlayBackground,
+    shouldObservePageTheme,
+    syncPageThemeObservation
   });
 });

--- a/src/overlay/search-panel.js
+++ b/src/overlay/search-panel.js
@@ -103,7 +103,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     console.warn('Lumno: site search store helper not available.');
     return;
   }
-  if (typeof SUGGESTION_NAVIGATION.scrollItemIntoView !== 'function') {
+  if (typeof SUGGESTION_NAVIGATION.scrollItemIntoView !== 'function' ||
+      typeof SUGGESTION_NAVIGATION.getVisibleRowsViewportHeight !== 'function') {
     console.warn('Lumno: suggestion navigation helper not available.');
     return;
   }
@@ -460,11 +461,6 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     }
     const suggestions = Array.isArray(list) ? list : [];
     return suggestions.slice(0, normalizeSearchResultDisplayLimit(overlaySearchResultDisplayLimit));
-  }
-
-  function limitOverlayTabsForDisplay(list) {
-    const tabList = Array.isArray(list) ? list : [];
-    return tabList.slice(0, normalizeSearchResultDisplayLimit(overlaySearchResultDisplayLimit));
   }
 
   function loadOverlaySearchBlacklistItems(onReload) {
@@ -1764,12 +1760,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       if (overlayToastElement) {
         overlayToastElement.setAttribute('data-theme', nextResolvedTheme || 'light');
       }
+      syncOverlayPageThemeObservation();
       if (mode === 'system') {
-        if (overlayPageThemeAdaptationEnabled) {
-          startOverlayPageThemeObserver();
-        } else {
-          stopOverlayPageThemeObserver();
-        }
         if (!overlayThemeListenerAttached) {
           overlayThemeMediaListener = function() {
             if (overlayThemeMode === 'system') {
@@ -1782,7 +1774,6 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
         }
         return;
       }
-      stopOverlayPageThemeObserver();
       if (overlayThemeListenerAttached) {
         overlayMediaQuery.removeEventListener('change', overlayThemeMediaListener);
         overlayThemeMediaListener = null;
@@ -2328,6 +2319,49 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       }
       suggestionsContainer.setAttribute('data-scope-result-enter', 'done');
     });
+    function readComputedCssPixels(computedStyle, property) {
+      if (!computedStyle) {
+        return 0;
+      }
+      const rawValue = property.startsWith('--') &&
+          typeof computedStyle.getPropertyValue === 'function'
+        ? computedStyle.getPropertyValue(property)
+        : computedStyle[property];
+      const value = Number.parseFloat(rawValue);
+      return Number.isFinite(value) ? Math.max(0, value) : 0;
+    }
+    function setOpenTabsResultsViewport(active, itemCount) {
+      if (!active) {
+        suggestionsContainer.style.removeProperty('--x-ov-suggestions-max-height');
+        suggestionsContainer.removeAttribute('data-open-tabs-visible-row-limit');
+        return;
+      }
+      const visibleRowLimit = normalizeSearchResultDisplayLimit(
+        overlaySearchResultDisplayLimit
+      );
+      suggestionsContainer.setAttribute(
+        'data-open-tabs-visible-row-limit',
+        String(visibleRowLimit)
+      );
+      const computedStyle = window.getComputedStyle(suggestionsContainer);
+      const maxHeight = SUGGESTION_NAVIGATION.getVisibleRowsViewportHeight({
+        visibleRowLimit,
+        itemCount,
+        rowHeight: readComputedCssPixels(computedStyle, '--x-ov-suggestion-row-height'),
+        rowGap: readComputedCssPixels(computedStyle, '--x-ov-suggestion-row-gap'),
+        paddingTop: readComputedCssPixels(computedStyle, 'paddingTop'),
+        paddingBottom: readComputedCssPixels(computedStyle, 'paddingBottom')
+      });
+      if (maxHeight > 0) {
+        suggestionsContainer.style.setProperty(
+          '--x-ov-suggestions-max-height',
+          `${maxHeight}px`,
+          inputUsesIsolatedStyles ? '' : 'important'
+        );
+      } else {
+        suggestionsContainer.style.removeProperty('--x-ov-suggestions-max-height');
+      }
+    }
     let suggestionsHeightAnimationFrame = 0;
     let suggestionsHeightAnimationTimer = 0;
     let suggestionsHeightTransitionEndHandler = null;
@@ -2469,6 +2503,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
 
     function clearDefaultOpenTabsSuggestions() {
       ensureOverlaySuggestionsView().clear();
+      setOpenTabsResultsViewport(false);
       suggestionsContainer.removeAttribute('data-scope-result-enter');
       suggestionItems.length = 0;
       currentSuggestions = [];
@@ -3087,6 +3122,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       },
       dark: {
         bg: 'rgba(20, 20, 20, 0.62)',
+        lightPageBg: 'rgba(20, 20, 20, 0.82)',
         modeMenuBg: '#141414',
         border: 'rgba(255, 255, 255, 0.16)',
         shadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 2px 6px -2px rgba(0, 0, 0, 0.28), 0 18px 48px -14px rgba(0, 0, 0, 0.42), 0 52px 124px -34px rgba(0, 0, 0, 0.52)',
@@ -3106,10 +3142,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
         saturate: '145%'
       }
     };
-    function resolveOverlayTheme(mode) {
-      const pageTheme = mode === 'system' && overlayPageThemeAdaptationEnabled
-        ? detectPageTheme()
-        : null;
+    function resolveOverlayTheme(mode, pageTheme) {
       const systemTheme = overlayMediaQuery.matches ? 'dark' : 'light';
       if (overlayPageTheme && typeof overlayPageTheme.resolveOverlayTheme === 'function') {
         return overlayPageTheme.resolveOverlayTheme({
@@ -3122,7 +3155,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       if (mode === 'dark' || mode === 'light') {
         return mode;
       }
-      return pageTheme || systemTheme;
+      return overlayPageThemeAdaptationEnabled && pageTheme ? pageTheme : systemTheme;
     }
 
     function pushThemeCandidate(candidates, element) {
@@ -3324,14 +3357,25 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     }
 
     function getThemeSignalFromCssColor(color, weight) {
-      let rgb = parseCssColor(color);
-      if ((!rgb || rgb.length !== 3) &&
-          overlayPageTheme &&
-          typeof overlayPageTheme.parseCssColor === 'function') {
+      if (overlayPageTheme && typeof overlayPageTheme.getCssColorThemeSignal === 'function') {
+        return overlayPageTheme.getCssColorThemeSignal(color, weight);
+      }
+      let rgb = null;
+      if (overlayPageTheme && typeof overlayPageTheme.parseCssColor === 'function') {
         const parsed = overlayPageTheme.parseCssColor(color);
-        if (parsed && parsed.rgb && parsed.rgb.length === 3 && parsed.alpha > 0.08) {
-          rgb = parsed.rgb;
+        if (parsed && parsed.rgb && parsed.rgb.length === 3) {
+          if (parsed.alpha <= 0.08) {
+            return null;
+          }
+          rgb = parsed.alpha < 1
+            ? parsed.rgb.map((channel) => Math.round(
+              (channel * parsed.alpha) + (255 * (1 - parsed.alpha))
+            ))
+            : parsed.rgb;
         }
+      }
+      if (!rgb || rgb.length !== 3) {
+        rgb = parseCssColor(color);
       }
       return getThemeSignalFromRgb(rgb, weight);
     }
@@ -3379,6 +3423,9 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     }
 
     function resolvePageThemeSignals(signals) {
+      if (overlayPageTheme && typeof overlayPageTheme.resolvePageThemeSignals === 'function') {
+        return overlayPageTheme.resolvePageThemeSignals(signals);
+      }
       let totalScore = 0;
       let totalWeight = 0;
       signals.forEach((signal) => {
@@ -3437,11 +3484,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       const bgColor = (bodyStyle && bodyStyle.backgroundColor && bodyStyle.backgroundColor !== 'transparent')
         ? bodyStyle.backgroundColor
         : docStyle.backgroundColor;
-      const rgb = parseCssColor(bgColor);
-      if (rgb && rgb.length === 3) {
-        return getLuminance(rgb) < 0.42 ? 'dark' : 'light';
-      }
-      return null;
+      const backgroundSignal = getThemeSignalFromCssColor(bgColor, 1);
+      return backgroundSignal ? backgroundSignal.theme : null;
     }
 
     function scheduleOverlayPageThemeSync() {
@@ -3450,17 +3494,50 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       }
       overlayPageThemeSyncRaf = requestAnimationFrame(() => {
         overlayPageThemeSyncRaf = null;
-        if (!overlay || !overlay.isConnected || overlayThemeMode !== 'system' ||
-            !overlayPageThemeAdaptationEnabled) {
+        if (!overlay || !overlay.isConnected || !shouldObserveOverlayPageTheme()) {
           return;
         }
-        applyOverlayTheme('system');
+        applyOverlayTheme(overlayThemeMode);
       });
     }
 
+    function shouldObserveOverlayPageTheme() {
+      if (overlayPageTheme && typeof overlayPageTheme.shouldObservePageTheme === 'function') {
+        return overlayPageTheme.shouldObservePageTheme({
+          mode: overlayThemeMode,
+          pageThemeAdaptationEnabled: overlayPageThemeAdaptationEnabled,
+          systemTheme: overlayMediaQuery.matches ? 'dark' : 'light'
+        });
+      }
+      if (overlayThemeMode === 'dark') {
+        return true;
+      }
+      if (overlayThemeMode !== 'system') {
+        return false;
+      }
+      return overlayPageThemeAdaptationEnabled || overlayMediaQuery.matches;
+    }
+
+    function syncOverlayPageThemeObservation() {
+      if (overlayPageTheme && typeof overlayPageTheme.syncPageThemeObservation === 'function') {
+        return overlayPageTheme.syncPageThemeObservation({
+          mode: overlayThemeMode,
+          pageThemeAdaptationEnabled: overlayPageThemeAdaptationEnabled,
+          systemTheme: overlayMediaQuery.matches ? 'dark' : 'light',
+          start: startOverlayPageThemeObserver,
+          stop: stopOverlayPageThemeObserver
+        });
+      }
+      if (shouldObserveOverlayPageTheme()) {
+        startOverlayPageThemeObserver();
+        return true;
+      }
+      stopOverlayPageThemeObserver();
+      return false;
+    }
+
     function startOverlayPageThemeObserver() {
-      if (overlayPageThemeObserver || overlayThemeMode !== 'system' ||
-          !overlayPageThemeAdaptationEnabled) {
+      if (overlayPageThemeObserver || !shouldObserveOverlayPageTheme()) {
         return;
       }
       const themeAttrFilter = [
@@ -3510,10 +3587,21 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       if (!target) {
         return;
       }
-      const resolved = resolveOverlayTheme(mode);
+      const pageTheme = detectPageTheme();
+      const resolved = resolveOverlayTheme(mode, pageTheme);
       const tokens = overlayThemeTokens[resolved] || overlayThemeTokens.light;
+      const shouldStrengthenDarkBackground = overlayPageTheme &&
+        typeof overlayPageTheme.shouldStrengthenDarkOverlayBackground === 'function'
+        ? overlayPageTheme.shouldStrengthenDarkOverlayBackground({
+          resolvedTheme: resolved,
+          pageTheme
+        })
+        : resolved === 'dark' && pageTheme === 'light';
       target.setAttribute('data-theme', resolved);
-      target.style.setProperty('--x-ov-bg', tokens.bg);
+      target.style.setProperty(
+        '--x-ov-bg',
+        shouldStrengthenDarkBackground && tokens.lightPageBg ? tokens.lightPageBg : tokens.bg
+      );
       target.style.setProperty('--x-ov-mode-menu-bg', tokens.modeMenuBg);
       target.style.setProperty('--x-ov-border', tokens.border);
       target.style.setProperty('--x-ov-shadow', tokens.shadow);
@@ -7759,7 +7847,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       currentSuggestions = [];
       lastRenderedQuery = '';
       lastRenderedActionContextKey = '';
-      const list = limitOverlayTabsForDisplay(tabList);
+      const list = Array.isArray(tabList) ? tabList.slice() : [];
+      setOpenTabsResultsViewport(true, list.length);
       if (list.length === 0) {
         const emptyText = openTabsSearchModeActive
           ? t('overlay_empty_open_tabs', '未找到匹配的已打开标签页')
@@ -7778,6 +7867,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
         }
       });
       reactView.renderTabs(list);
+      suggestionsContainer.scrollTop = 0;
       setOverlayResultsCollapsed(false, { deferLayoutSync: true });
       selectedIndex = -1;
       updateSelection();
@@ -8456,6 +8546,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
           updateKind === 'highlight' || updateKind === 'content'
             ? null
             : captureSuggestionsHeightState(suggestionsContainer);
+        setOpenTabsResultsViewport(false);
         const reactView = ensureOverlaySuggestionsView();
         currentSuggestions = allSuggestions;
         lastRenderedQuery = query;

--- a/src/overlay/suggestions-view.css
+++ b/src/overlay/suggestions-view.css
@@ -36,6 +36,44 @@
   overflow-y: hidden;
 }
 
+:is(#_x_extension_overlay_2024_unique_, #_x_extension_onboarding_overlay_demo_2026_unique_) .x-ov-suggestions-container[data-open-tabs-visible-row-limit] {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.68) transparent;
+}
+
+:is(#_x_extension_overlay_2024_unique_, #_x_extension_onboarding_overlay_demo_2026_unique_) .x-ov-suggestions-container[data-open-tabs-visible-row-limit]::-webkit-scrollbar {
+  width: 10px;
+}
+
+:is(#_x_extension_overlay_2024_unique_, #_x_extension_onboarding_overlay_demo_2026_unique_) .x-ov-suggestions-container[data-open-tabs-visible-row-limit]::-webkit-scrollbar-track {
+  margin-block: 12px;
+  background: transparent;
+}
+
+:is(#_x_extension_overlay_2024_unique_, #_x_extension_onboarding_overlay_demo_2026_unique_) .x-ov-suggestions-container[data-open-tabs-visible-row-limit]::-webkit-scrollbar-thumb {
+  min-height: 40px;
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-color: rgba(148, 163, 184, 0.68);
+  background-clip: padding-box;
+}
+
+:is(#_x_extension_overlay_2024_unique_, #_x_extension_onboarding_overlay_demo_2026_unique_) .x-ov-suggestions-container[data-open-tabs-visible-row-limit]::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(100, 116, 139, 0.82);
+}
+
+:is(#_x_extension_overlay_2024_unique_[data-theme="dark"], #_x_extension_onboarding_overlay_demo_2026_unique_[data-theme="dark"]) .x-ov-suggestions-container[data-open-tabs-visible-row-limit] {
+  scrollbar-color: rgba(148, 163, 184, 0.58) transparent;
+}
+
+:is(#_x_extension_overlay_2024_unique_[data-theme="dark"], #_x_extension_onboarding_overlay_demo_2026_unique_[data-theme="dark"]) .x-ov-suggestions-container[data-open-tabs-visible-row-limit]::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.58);
+}
+
+:is(#_x_extension_overlay_2024_unique_[data-theme="dark"], #_x_extension_onboarding_overlay_demo_2026_unique_[data-theme="dark"]) .x-ov-suggestions-container[data-open-tabs-visible-row-limit]::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(203, 213, 225, 0.7);
+}
+
 :is(#_x_extension_overlay_2024_unique_, #_x_extension_onboarding_overlay_demo_2026_unique_) .x-ov-close-other-tabs {
   all: unset;
   position: absolute;

--- a/src/shared/suggestion-navigation.js
+++ b/src/shared/suggestion-navigation.js
@@ -9,6 +9,27 @@
   const NUMBER_SHORTCUT_TIMEOUT_MS = 2000;
   const numberShortcutStates = new WeakMap();
 
+  function getVisibleRowsViewportHeight(options) {
+    const config = options && typeof options === 'object' ? options : {};
+    const visibleRowLimit = Math.max(0, Math.floor(Number(config.visibleRowLimit) || 0));
+    const itemCount = Math.max(0, Math.floor(Number(config.itemCount) || 0));
+    const rowHeight = Math.max(0, Number(config.rowHeight) || 0);
+    const rowGap = Math.max(0, Number(config.rowGap) || 0);
+    const paddingTop = Math.max(0, Number(config.paddingTop) || 0);
+    const paddingBottom = Math.max(0, Number(config.paddingBottom) || 0);
+    const visibleRowCount = Math.min(visibleRowLimit, itemCount);
+    if (visibleRowCount <= 0 || rowHeight <= 0) {
+      return 0;
+    }
+    const hasOverflow = itemCount > visibleRowCount;
+    const visibleGapCount = hasOverflow
+      ? visibleRowCount
+      : Math.max(0, visibleRowCount - 1);
+    return paddingTop + paddingBottom +
+      (visibleRowCount * rowHeight) +
+      (visibleGapCount * rowGap);
+  }
+
   function scrollItemIntoView(container, item, options) {
     if (!container || !item || !item.isConnected) {
       return;
@@ -315,6 +336,7 @@
   }
 
   return {
+    getVisibleRowsViewportHeight,
     scrollItemIntoView,
     handleNumberShortcutKeyEvent,
     setNumberShortcutsActive,


### PR DESCRIPTION
## What changed

- Tighten local search matching for top sites.
- Stabilize direct URL and open-tab rendering, with settle timing moved into a tested controller.
- Fix page-theme observation in forced dark mode and improve transparent-color theme signals.
- Render all open tabs in a CSS-token-derived scroll viewport with a visible scrollbar.

## Why

Several related search and overlay fixes had accumulated as inline patches. This change consolidates the behavior into reusable, testable policies and fixes a forced-dark observer that was being torn down immediately.

## Validation

- `npm run test:legacy` — 131 test files passed
- `npm run test:react` — 46 files / 237 tests passed
- `npm run check` — syntax, typecheck, builds, bundle, and manifest passed
- Browser QA at 1280×720 for scrolling plus light/dark adaptation
