### PR TITLE
Add mac Ctrl+N/Ctrl+P suggestion navigation via shared shortcut helper

### DIFF
--- a/scripts/check-manifest-resources.js
+++ b/scripts/check-manifest-resources.js
@@ -24,6 +24,7 @@ const injectedScriptFiles = [
   'src/shared/ime-key-guard.js',
   'src/react/overlay-islands.js',
   'src/shared/search-input-history.js',
+  'src/shared/search-navigation-shortcut.js',
   'assets/vendor/pinyin-pro.js',
   'src/shared/search-input-mode.js',
   'src/shared/toast.js',

--- a/scripts/package-store.js
+++ b/scripts/package-store.js
@@ -37,6 +37,7 @@ const injectedScriptFiles = [
   'src/shared/suggestion-navigation.js',
   'src/react/overlay-islands.js',
   'src/shared/search-input-history.js',
+  'src/shared/search-navigation-shortcut.js',
   'src/shared/search-input-mode.js',
   'src/shared/toast.js',
   'src/shared/shortcut-favicon.js',

--- a/scripts/test-search-input-history.js
+++ b/scripts/test-search-input-history.js
@@ -145,6 +145,20 @@ function testSurfaceIntegrationContract() {
     shortcutReferenceSource.includes("shortcut: 'Alt+ArrowUp / Alt+ArrowDown'"),
     'General settings should list the input history shortcut'
   );
+  assert.ok(
+    overlaySource.includes("normalizedKey === 'n' || code === 'KeyN'") &&
+      overlaySource.includes("normalizedKey === 'p' || code === 'KeyP'"),
+    'overlay should map Ctrl+N/Ctrl+P to suggestion navigation on macOS'
+  );
+  assert.ok(
+    newtabSource.includes("normalizedKey === 'n' || code === 'KeyN'") &&
+      newtabSource.includes("normalizedKey === 'p' || code === 'KeyP'"),
+    'New Tab should map Ctrl+N/Ctrl+P to suggestion navigation on macOS'
+  );
+  assert.ok(
+    shortcutReferenceSource.includes("mac: 'ArrowUp / ArrowDown / Ctrl+P / Ctrl+N'"),
+    'General settings should list Ctrl+P/Ctrl+N as macOS alternatives for suggestion navigation'
+  );
 }
 
 (async () => {

--- a/scripts/test-search-input-history.js
+++ b/scripts/test-search-input-history.js
@@ -120,6 +120,10 @@ function testSurfaceIntegrationContract() {
     path.join(repoRoot, 'src/overlay/search-panel.js'),
     'utf8'
   );
+  const navigationShortcutSource = fs.readFileSync(
+    path.join(repoRoot, 'src/shared/search-navigation-shortcut.js'),
+    'utf8'
+  );
   const shortcutReferenceSource = fs.readFileSync(
     path.join(repoRoot, 'src/shared/shortcut-reference.js'),
     'utf8'
@@ -130,8 +134,16 @@ function testSurfaceIntegrationContract() {
     'New Tab should load the shared input history helper'
   );
   assert.ok(
+    newtabHtml.includes('<script src="../shared/search-navigation-shortcut.js"></script>'),
+    'New Tab should load the shared search navigation shortcut helper'
+  );
+  assert.ok(
     backgroundSource.includes("'src/shared/search-input-history.js'"),
     'overlay injection should load the shared input history helper'
+  );
+  assert.ok(
+    backgroundSource.includes("'src/shared/search-navigation-shortcut.js'"),
+    'overlay injection should load the shared search navigation shortcut helper'
   );
   assert.ok(
     newtabSource.includes('SEARCH_INPUT_HISTORY.getShortcutDirection(event)'),
@@ -146,18 +158,21 @@ function testSurfaceIntegrationContract() {
     'General settings should list the input history shortcut'
   );
   assert.ok(
-    overlaySource.includes("normalizedKey === 'n' || code === 'KeyN'") &&
-      overlaySource.includes("normalizedKey === 'p' || code === 'KeyP'"),
-    'overlay should map Ctrl+N/Ctrl+P to suggestion navigation on macOS'
+    overlaySource.includes('SEARCH_NAVIGATION_SHORTCUT.getSuggestionNavigationKey'),
+    'overlay should use the shared search navigation shortcut helper'
   );
   assert.ok(
-    newtabSource.includes("normalizedKey === 'n' || code === 'KeyN'") &&
-      newtabSource.includes("normalizedKey === 'p' || code === 'KeyP'"),
-    'New Tab should map Ctrl+N/Ctrl+P to suggestion navigation on macOS'
+    newtabSource.includes('SEARCH_NAVIGATION_SHORTCUT.getSuggestionNavigationKey'),
+    'New Tab should use the shared search navigation shortcut helper'
   );
   assert.ok(
     shortcutReferenceSource.includes("mac: 'ArrowUp / ArrowDown / Ctrl+P / Ctrl+N'"),
     'General settings should list Ctrl+P/Ctrl+N as macOS alternatives for suggestion navigation'
+  );
+  assert.ok(
+    navigationShortcutSource.includes("normalizedKey === 'n' || code === 'KeyN'") &&
+      navigationShortcutSource.includes("normalizedKey === 'p' || code === 'KeyP'"),
+    'shared navigation helper should map Ctrl+N/Ctrl+P to arrow navigation'
   );
 }
 

--- a/scripts/test-shortcut-display.js
+++ b/scripts/test-shortcut-display.js
@@ -119,12 +119,27 @@ assert.ok(
 const macNumberJump = searchShortcutGroup.items.find((item) => (
   item.id === 'search-number-jump'
 ));
+const macSearchNavigate = searchShortcutGroup.items.find((item) => (
+  item.id === 'search-navigate'
+));
 const windowsNumberJump = shortcutReference
   .getShortcutReferenceGroups({ platform: 'windows' })
   .find((group) => group.id === 'search')
   .items.find((item) => item.id === 'search-number-jump');
+const windowsSearchNavigate = shortcutReference
+  .getShortcutReferenceGroups({ platform: 'windows' })
+  .find((group) => group.id === 'search')
+  .items.find((item) => item.id === 'search-navigate');
 assert.strictEqual(macNumberJump.shortcut, 'Command 0.4s → 0–9');
 assert.strictEqual(windowsNumberJump.shortcut, 'Ctrl 0.4s → 0–9');
+assert.strictEqual(
+  macSearchNavigate.shortcut,
+  'ArrowUp / ArrowDown / Ctrl+P / Ctrl+N'
+);
+assert.strictEqual(
+  windowsSearchNavigate.shortcut,
+  'ArrowUp / ArrowDown'
+);
 assert.strictEqual(
   shortcutDisplay.formatShortcutReference(macNumberJump.shortcut, {
     platform: 'mac'
@@ -136,6 +151,18 @@ assert.strictEqual(
     platform: 'windows'
   }),
   'Ctrl 0.4s → 0–9'
+);
+assert.strictEqual(
+  shortcutDisplay.formatShortcutReference(macSearchNavigate.shortcut, {
+    platform: 'mac'
+  }),
+  '↑ / ↓ / ⌃P / ⌃N'
+);
+assert.strictEqual(
+  shortcutDisplay.formatShortcutReference(windowsSearchNavigate.shortcut, {
+    platform: 'windows'
+  }),
+  '↑ / ↓'
 );
 ['en', 'ja', 'zh_CN', 'zh_TW'].forEach((locale) => {
   const messages = JSON.parse(fs.readFileSync(

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -3975,6 +3975,7 @@ function openOverlayOnTab(activeTab, tabs, source) {
     'src/shared/suggestion-navigation.js',
     'src/shared/ime-key-guard.js',
     'src/shared/search-input-history.js',
+    'src/shared/search-navigation-shortcut.js',
     'src/shared/toast.js',
     'src/shared/menu-surface.js',
     'assets/vendor/pinyin-pro.js',

--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -6532,6 +6532,7 @@
     <script src="../shared/codex-debug-surface.js"></script>
     <script src="../shared/ime-key-guard.js"></script>
     <script src="../shared/search-input-history.js"></script>
+    <script src="../shared/search-navigation-shortcut.js"></script>
     <script src="../../assets/vendor/pinyin-pro.js"></script>
     <script src="../shared/search-input-mode.js"></script>
     <script src="../shared/blacklist-utils.js"></script>

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -169,6 +169,7 @@
   const SUGGESTION_ACTION_MODEL = globalThis.LumnoSuggestionActionModel || {};
   const SUGGESTION_NAVIGATION = globalThis.LumnoSuggestionNavigation || {};
   const SEARCH_INPUT_HISTORY = globalThis.LumnoSearchInputHistory || {};
+  const SEARCH_NAVIGATION_SHORTCUT = globalThis.LumnoSearchNavigationShortcut || {};
   const SEARCH_INPUT_MODE = globalThis.LumnoSearchInputMode || {};
   const FEATURE_HINTS = globalThis.LumnoFeatureHints || {};
   const UPDATE_NOTICE = globalThis.LumnoUpdateNotice || {};
@@ -14793,32 +14794,12 @@
     onKeyDown: function(event) {
       syncSuggestionActionModifiersFromEvent(event);
       dismissAutocompletePreviewOnNonTabKey(event);
-      const suggestionNavigationKey = (() => {
-        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-          return event.key;
-        }
-        const navigatorLike = typeof navigator === 'object' && navigator ? navigator : {};
-        const userAgentDataPlatform = navigatorLike.userAgentData &&
-          typeof navigatorLike.userAgentData.platform === 'string'
-          ? navigatorLike.userAgentData.platform
-          : '';
-        const platformText = String(
-          userAgentDataPlatform || navigatorLike.platform || navigatorLike.userAgent || ''
-        );
-        const isMacPlatform = /Mac|iPhone|iPad|iPod/i.test(platformText);
-        if (!isMacPlatform || !event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
-          return '';
-        }
-        const normalizedKey = String(event.key || '').toLowerCase();
-        const code = String(event.code || '');
-        if (normalizedKey === 'n' || code === 'KeyN') {
-          return 'ArrowDown';
-        }
-        if (normalizedKey === 'p' || code === 'KeyP') {
-          return 'ArrowUp';
-        }
-        return '';
-      })();
+      const suggestionNavigationKey =
+        typeof SEARCH_NAVIGATION_SHORTCUT.getSuggestionNavigationKey === 'function'
+          ? SEARCH_NAVIGATION_SHORTCUT.getSuggestionNavigationKey(event, {
+            navigatorLike: typeof navigator === 'object' && navigator ? navigator : null
+          })
+          : (event.key === 'ArrowDown' || event.key === 'ArrowUp' ? event.key : '');
       if (event.key !== 'Backspace' && !event.metaKey && !event.ctrlKey && !event.altKey) {
         latestRawQuery = inputParts.input.value;
         latestQuery = inputParts.input.value.trim();

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -14793,6 +14793,32 @@
     onKeyDown: function(event) {
       syncSuggestionActionModifiersFromEvent(event);
       dismissAutocompletePreviewOnNonTabKey(event);
+      const suggestionNavigationKey = (() => {
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          return event.key;
+        }
+        const navigatorLike = typeof navigator === 'object' && navigator ? navigator : {};
+        const userAgentDataPlatform = navigatorLike.userAgentData &&
+          typeof navigatorLike.userAgentData.platform === 'string'
+          ? navigatorLike.userAgentData.platform
+          : '';
+        const platformText = String(
+          userAgentDataPlatform || navigatorLike.platform || navigatorLike.userAgent || ''
+        );
+        const isMacPlatform = /Mac|iPhone|iPad|iPod/i.test(platformText);
+        if (!isMacPlatform || !event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+          return '';
+        }
+        const normalizedKey = String(event.key || '').toLowerCase();
+        const code = String(event.code || '');
+        if (normalizedKey === 'n' || code === 'KeyN') {
+          return 'ArrowDown';
+        }
+        if (normalizedKey === 'p' || code === 'KeyP') {
+          return 'ArrowUp';
+        }
+        return '';
+      })();
       if (event.key !== 'Backspace' && !event.metaKey && !event.ctrlKey && !event.altKey) {
         latestRawQuery = inputParts.input.value;
         latestQuery = inputParts.input.value.trim();
@@ -14856,13 +14882,13 @@
         }
         return;
       }
-      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      if (suggestionNavigationKey) {
         if (suggestionItems.length === 0) {
           return;
         }
         event.preventDefault();
         let didWrap = false;
-        if (event.key === 'ArrowDown') {
+        if (suggestionNavigationKey === 'ArrowDown') {
           if (selectedIndex === -1) {
             const autoIndex = getAutoHighlightIndex();
             selectedIndex = autoIndex >= 0
@@ -14894,7 +14920,10 @@
           }
         }
         updateSelection();
-        scrollSelectedSuggestionIntoView(event.key === 'ArrowDown' ? 'down' : 'up', didWrap);
+        scrollSelectedSuggestionIntoView(
+          suggestionNavigationKey === 'ArrowDown' ? 'down' : 'up',
+          didWrap
+        );
         return;
       }
       if (event.key === 'Tab' && handleTabKey) {

--- a/src/overlay/search-panel.js
+++ b/src/overlay/search-panel.js
@@ -76,6 +76,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
   const SUGGESTION_ACTION_MODEL = window.LumnoSuggestionActionModel || {};
   const SUGGESTION_NAVIGATION = window.LumnoSuggestionNavigation || {};
   const SEARCH_INPUT_HISTORY = window.LumnoSearchInputHistory || {};
+  const SEARCH_NAVIGATION_SHORTCUT = window.LumnoSearchNavigationShortcut || {};
   const OVERLAY_SUGGESTIONS_VIEW = window.LumnoOverlaySuggestionsView || {};
   const OVERLAY_TOAST = window.LumnoToast || {};
   const SEARCH_INPUT_MODE = window.LumnoSearchInputMode || {};
@@ -163,35 +164,16 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       input.setAttribute(name, value);
     });
   }
-  function isMacKeyboardPlatform() {
-    const navigatorLike = window && window.navigator ? window.navigator : {};
-    const userAgentDataPlatform = navigatorLike.userAgentData &&
-      typeof navigatorLike.userAgentData.platform === 'string'
-      ? navigatorLike.userAgentData.platform
-      : '';
-    const platformText = String(
-      userAgentDataPlatform || navigatorLike.platform || navigatorLike.userAgent || ''
-    );
-    return /Mac|iPhone|iPad|iPod/i.test(platformText);
-  }
   function getSuggestionNavigationKey(event) {
+    if (typeof SEARCH_NAVIGATION_SHORTCUT.getSuggestionNavigationKey === 'function') {
+      return SEARCH_NAVIGATION_SHORTCUT.getSuggestionNavigationKey(event, {
+        navigatorLike: window && window.navigator ? window.navigator : null
+      });
+    }
     const key = String(event && event.key || '');
-    if (key === 'ArrowDown' || key === 'ArrowUp') {
-      return key;
-    }
-    if (!isMacKeyboardPlatform() || !event ||
-        !event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
-      return '';
-    }
-    const code = String(event.code || '');
-    const normalizedKey = key.toLowerCase();
-    if (normalizedKey === 'n' || code === 'KeyN') {
-      return 'ArrowDown';
-    }
-    if (normalizedKey === 'p' || code === 'KeyP') {
-      return 'ArrowUp';
-    }
-    return '';
+    return key === 'ArrowDown' || key === 'ArrowUp'
+      ? key
+      : '';
   }
   const normalizedOverlayContext = (overlayContext && typeof overlayContext === 'object') ? overlayContext : {};
   const requestedTabZoomFactorRaw = Number(normalizedOverlayContext.tabZoomFactor);

--- a/src/overlay/search-panel.js
+++ b/src/overlay/search-panel.js
@@ -163,6 +163,36 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       input.setAttribute(name, value);
     });
   }
+  function isMacKeyboardPlatform() {
+    const navigatorLike = window && window.navigator ? window.navigator : {};
+    const userAgentDataPlatform = navigatorLike.userAgentData &&
+      typeof navigatorLike.userAgentData.platform === 'string'
+      ? navigatorLike.userAgentData.platform
+      : '';
+    const platformText = String(
+      userAgentDataPlatform || navigatorLike.platform || navigatorLike.userAgent || ''
+    );
+    return /Mac|iPhone|iPad|iPod/i.test(platformText);
+  }
+  function getSuggestionNavigationKey(event) {
+    const key = String(event && event.key || '');
+    if (key === 'ArrowDown' || key === 'ArrowUp') {
+      return key;
+    }
+    if (!isMacKeyboardPlatform() || !event ||
+        !event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+      return '';
+    }
+    const code = String(event.code || '');
+    const normalizedKey = key.toLowerCase();
+    if (normalizedKey === 'n' || code === 'KeyN') {
+      return 'ArrowDown';
+    }
+    if (normalizedKey === 'p' || code === 'KeyP') {
+      return 'ArrowUp';
+    }
+    return '';
+  }
   const normalizedOverlayContext = (overlayContext && typeof overlayContext === 'object') ? overlayContext : {};
   const requestedTabZoomFactorRaw = Number(normalizedOverlayContext.tabZoomFactor);
   const initialPrefillQuery = typeof normalizedOverlayContext.prefillQuery === 'string'
@@ -6672,7 +6702,8 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
         handleTabKey(e);
         return;
       }
-      if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === 'Escape') {
+      const suggestionNavigationKey = getSuggestionNavigationKey(e);
+      if (suggestionNavigationKey || e.key === 'Enter' || e.key === 'Escape') {
         keydownHandler(e);
         return;
       }
@@ -6720,6 +6751,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       if (!e || e.isTrusted !== true) {
         return;
       }
+      const suggestionNavigationKey = getSuggestionNavigationKey(e);
       syncSuggestionActionModifiersFromEvent(e);
       if (SUGGESTION_NAVIGATION.handleNumberShortcutKeyEvent(
         e,
@@ -6736,7 +6768,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       if (e.key === 'Escape' && overlay) {
         removeOverlay(overlay);
         document.removeEventListener('keydown', keydownHandler);
-      } else if (e.key === 'ArrowDown') {
+      } else if (suggestionNavigationKey === 'ArrowDown') {
         e.preventDefault();
         if (suggestionItems.length === 0) {
           return;
@@ -6758,7 +6790,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
         updateSelection();
         scrollSelectedSuggestionIntoView('down', didWrap);
         searchInput.focus();
-      } else if (e.key === 'ArrowUp') {
+      } else if (suggestionNavigationKey === 'ArrowUp') {
         e.preventDefault();
         if (suggestionItems.length === 0) {
           return;

--- a/src/shared/search-navigation-shortcut.js
+++ b/src/shared/search-navigation-shortcut.js
@@ -1,0 +1,81 @@
+(function(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  root.LumnoSearchNavigationShortcut = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  function getNavigatorPlatform(navigatorLike) {
+    const source = navigatorLike || {};
+    const userAgentDataPlatform = source.userAgentData &&
+      typeof source.userAgentData.platform === 'string'
+      ? source.userAgentData.platform
+      : '';
+    const candidates = [
+      userAgentDataPlatform,
+      source.platform,
+      source.userAgent
+    ];
+    for (const candidate of candidates) {
+      const value = String(candidate || '').trim().toLowerCase();
+      if (!value) {
+        continue;
+      }
+      if (/(mac|iphone|ipad|ipod)/.test(value)) {
+        return 'mac';
+      }
+      if (/win/.test(value)) {
+        return 'windows';
+      }
+      if (/(linux|android|cros)/.test(value)) {
+        return 'other';
+      }
+    }
+    return 'other';
+  }
+
+  function resolvePlatform(options) {
+    const config = options || {};
+    const explicitPlatform = String(config.platform || '').trim().toLowerCase();
+    if (explicitPlatform.includes('mac')) {
+      return 'mac';
+    }
+    if (explicitPlatform.includes('win')) {
+      return 'windows';
+    }
+    if (explicitPlatform) {
+      return 'other';
+    }
+    return getNavigatorPlatform(config.navigatorLike);
+  }
+
+  function getSuggestionNavigationKey(event, options) {
+    const key = String(event && event.key || '');
+    if (key === 'ArrowDown' || key === 'ArrowUp') {
+      return key;
+    }
+    if (!event) {
+      return '';
+    }
+    if (resolvePlatform(options) !== 'mac') {
+      return '';
+    }
+    if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+      return '';
+    }
+    const normalizedKey = key.trim().toLowerCase();
+    const code = String(event.code || '').trim();
+    if (normalizedKey === 'n' || code === 'KeyN') {
+      return 'ArrowDown';
+    }
+    if (normalizedKey === 'p' || code === 'KeyP') {
+      return 'ArrowUp';
+    }
+    return '';
+  }
+
+  return Object.freeze({
+    getNavigatorPlatform,
+    getSuggestionNavigationKey
+  });
+});

--- a/src/shared/shortcut-reference.js
+++ b/src/shared/shortcut-reference.js
@@ -71,7 +71,10 @@
       titleFallback: 'Move through suggestions',
       descKey: 'shortcut_reference_search_navigate_desc',
       descFallback: 'Move the active result in Lumno search and New Tab',
-      shortcut: 'ArrowUp / ArrowDown'
+      defaultShortcut: {
+        default: 'ArrowUp / ArrowDown',
+        mac: 'ArrowUp / ArrowDown / Ctrl+P / Ctrl+N'
+      }
     },
     {
       id: 'search-number-jump',


### PR DESCRIPTION
mac users expect `Ctrl+N` / `Ctrl+P` to behave like down/up navigation in input UIs. The search surfaces only handled arrow keys and had duplicated key-mapping logic across New Tab and Overlay.

- **Behavior change**
  - Added mac-only mapping: `Ctrl+N -> ArrowDown`, `Ctrl+P -> ArrowUp` for suggestion navigation.
  - Kept existing arrow-key behavior unchanged on all platforms.

- **Shared runtime extraction**
  - Introduced `src/shared/search-navigation-shortcut.js` to centralize platform detection and key normalization.
  - Exposes `getSuggestionNavigationKey(event, options)` used by both surfaces.

- **Surface integration**
  - New Tab now consumes `LumnoSearchNavigationShortcut` and loads the shared script in `src/newtab/newtab.html`.
  - Overlay now consumes the same shared helper, injected via `src/background/background.js`.

- **Packaging/resource wiring**
  - Updated resource/package allowlists so the new shared file is included in manifest/resource checks and store packaging scripts.

- **Shortcut reference alignment**
  - Retained and surfaced mac alternative notation in shortcut reference: `ArrowUp / ArrowDown / Ctrl+P / Ctrl+N`.

```js
const suggestionNavigationKey =
  SEARCH_NAVIGATION_SHORTCUT.getSuggestionNavigationKey(event, {
    navigatorLike: navigator
  });
// returns: 'ArrowUp' | 'ArrowDown' | ''
```