### PR TITLE
Preserve Lumno across page loading and navigation

### DIFF
--- a/scripts/test-overlay-fast-open.js
+++ b/scripts/test-overlay-fast-open.js
@@ -13,19 +13,175 @@ assert.match(
   /const activeUrl = getResolvedTabUrl\(tab\);[\s\S]*?if \(canOpenOverlayOnUrl\(activeUrl\)\) \{[\s\S]*?openOverlayOnTab\(tab, \[\], source\);[\s\S]*?return;[\s\S]*?chrome\.tabs\.query/,
   'injectable pages should start opening immediately and reserve a tab query for restricted-page recovery'
 );
+assert.match(
+  triggerSource,
+  /if \(getPendingOverlayNavigationUrl\(tab\)\) \{[\s\S]*?openOverlayOnTab\(tab, \[\], source\);[\s\S]*?return;/,
+  'a shortcut on a provisional HTTP(S) navigation should record intent without waiting for a tab refresh'
+);
+
+const pendingIntentStart = backgroundSource.indexOf(
+  'function rememberOverlayPendingNavigationIntent(activeTab, source, pendingUrl)'
+);
+const pendingRuleStart = backgroundSource.indexOf(
+  'function getPendingOverlayNavigationUrl(tab)'
+);
+const pendingRuleSource = backgroundSource.slice(pendingRuleStart, pendingIntentStart);
+assert.ok(
+  pendingRuleStart >= 0 && pendingIntentStart > pendingRuleStart,
+  'shared pending-navigation rule should remain discoverable'
+);
+assert.match(
+  pendingRuleSource,
+  /getPendingInjectableUrl\([\s\S]*?tab,[\s\S]*?canOpenOverlayOnUrl[\s\S]*?\)/,
+  'pending navigation should use the same URL capability guard as ordinary Overlay injection'
+);
+assert.doesNotMatch(
+  pendingRuleSource,
+  /accounts\.google|feishu|dribbble|hostname|hostMatches/,
+  'the pending-navigation rule must stay capability-based rather than site-specific'
+);
+const pendingIntentEnd = backgroundSource.indexOf(
+  '\nfunction queueOverlayLoadingUpdate',
+  pendingIntentStart
+);
+const pendingIntentSource = backgroundSource.slice(pendingIntentStart, pendingIntentEnd);
+assert.ok(
+  pendingIntentStart >= 0 && pendingIntentEnd > pendingIntentStart,
+  'pending-navigation intent helper should remain discoverable'
+);
+assert.match(
+  pendingIntentSource,
+  /createRecord\(activeTab, source, Date\.now\(\)\)[\s\S]*?pendingNavigationUrl: pendingUrl[\s\S]*?setOverlayLoadingRecord\(nextRecord\)/,
+  'a provisional navigation should persist the same loading-lifecycle record used after commit'
+);
+assert.doesNotMatch(
+  pendingIntentSource,
+  /overlayLoadingRecoveryInFlightByTabId\.add|open(?:Browser)?NewtabFallback/,
+  'recording a provisional navigation must neither claim an injection is in flight nor open a fallback tab'
+);
 
 const runtimeVersionMatch = overlaySource.match(
   /_x_extension_search_overlay_runtime_version_2026_unique_\s*=\s*\n?\s*'([^']+)'/
 );
 assert.ok(runtimeVersionMatch, 'overlay should publish a runtime version for safe same-page reuse');
 assert.ok(
-  backgroundSource.includes(`const expectedOverlayRuntimeVersion = '${runtimeVersionMatch[1]}'`),
+  backgroundSource.includes(`const OVERLAY_RUNTIME_VERSION = '${runtimeVersionMatch[1]}'`),
   'background and injected overlay should agree on the reusable runtime version'
+);
+const immediateOpenStart = backgroundSource.indexOf('function openOverlayOnTab(');
+const immediateOpenSource = backgroundSource.slice(immediateOpenStart, triggerStart);
+assert.strictEqual(
+  (immediateOpenSource.match(/injectImmediately:\s*true/g) || []).length,
+  3,
+  'runtime probing, file injection, and Overlay activation should all bypass document_idle'
+);
+const loadingProbeStart = backgroundSource.indexOf('function probeOverlayLoadingState(');
+const loadingProbeEnd = backgroundSource.indexOf(
+  '\nfunction scheduleOverlayLoadingRecoveryRetry',
+  loadingProbeStart
+);
+const loadingProbeSource = backgroundSource.slice(loadingProbeStart, loadingProbeEnd);
+assert.match(
+  loadingProbeSource,
+  /target: \{ tabId \},\s*injectImmediately: true,/,
+  'loading recovery should probe the committed Document without waiting for document_idle'
 );
 assert.match(
   backgroundSource,
-  /chrome\.scripting\.executeScript\(\{\s*target: \{tabId: activeTab\.id\},\s*func: \(runtimeVersion\) => \{[\s\S]*?_x_extension_search_overlay_runtime_version_2026_unique_[\s\S]*?_x_extension_toggleSearchOverlay_2026_unique_[\s\S]*?args: \[expectedOverlayRuntimeVersion\][\s\S]*?if \(runtimeReady\) \{[\s\S]*?runOverlayWithResolvedZoom\(\);\s*return;\s*\}[\s\S]*?injectOverlayRuntime\(\);/,
+  /chrome\.scripting\.executeScript\(\{\s*target: \{tabId: activeTab\.id\},\s*injectImmediately: true,\s*func: \(runtimeVersion\) => \{[\s\S]*?_x_extension_search_overlay_runtime_version_2026_unique_[\s\S]*?_x_extension_toggleSearchOverlay_2026_unique_[\s\S]*?args: \[OVERLAY_RUNTIME_VERSION\][\s\S]*?if \(runtimeReady\) \{[\s\S]*?runOverlayWithResolvedZoom\(\);\s*return;\s*\}[\s\S]*?injectOverlayRuntime\(\);/,
   'same-page reopen should call the existing runtime and inject the full file set only after a failed version probe'
+);
+assert.match(
+  backgroundSource,
+  /const overlayOpeningByTabId = new Map\(\);[\s\S]*?function beginOverlayOpening\(tab, source\)[\s\S]*?overlayOpeningByTabId\.set\(tab\.id, opening\);/,
+  'each tab should keep a bounded guard against concurrent Overlay startup'
+);
+assert.match(
+  backgroundSource,
+  /function recoverOverlayAfterLoadingUpdate\(tabId, changeInfo, tab\)[\s\S]*?probeOverlayLoadingState\(tabId,[\s\S]*?OVERLAY_LOADING_LIFECYCLE\.decideRecovery[\s\S]*?restoreOverlayAfterLoadingDocumentChange/,
+  'loading completion should probe the current Document and restore only when lifecycle state requires it'
+);
+assert.match(
+  backgroundSource,
+  /function restoreOverlayAfterLoadingDocumentChange\(tab, record, complete\)[\s\S]*?loadingRecovery: true,[\s\S]*?loadingRecord: record,[\s\S]*?ensureOpen: true/,
+  'loading recovery should use idempotent ensure-open semantics and carry the saved session record'
+);
+assert.match(
+  backgroundSource,
+  /function scheduleOverlayLoadingRecoveryRetry\(tab, record\)[\s\S]*?OVERLAY_LOADING_RECOVERY_MAX_ATTEMPTS[\s\S]*?recoverOverlayAfterLoadingUpdate\(tab\.id, \{ status: 'complete' \}, tab\)[\s\S]*?if \(complete === true\) \{[\s\S]*?if \(ok\) \{[\s\S]*?clearOverlayLoadingRecord\(tab\.id\);[\s\S]*?scheduleOverlayLoadingRecoveryRetry\(tab, record\);/,
+  'a transient final-Document injection failure should retry without prematurely discarding the session'
+);
+const preCompleteRetryStart = backgroundSource.indexOf(
+  'function scheduleOverlayLoadingPreCompleteRetry(tab, record)'
+);
+const preCompleteRetryEnd = backgroundSource.indexOf(
+  '\nfunction restoreOverlayAfterLoadingDocumentChange',
+  preCompleteRetryStart
+);
+const preCompleteRetrySource = backgroundSource.slice(
+  preCompleteRetryStart,
+  preCompleteRetryEnd
+);
+assert.ok(
+  preCompleteRetryStart >= 0 && preCompleteRetryEnd > preCompleteRetryStart,
+  'pre-complete loading retry helper should remain discoverable'
+);
+assert.match(
+  preCompleteRetrySource,
+  /OVERLAY_LOADING_PRE_COMPLETE_RETRY_MAX_ATTEMPTS[\s\S]*?getOverlayLoadingRecord\(tab\.id,[\s\S]*?retryTab\.status === 'complete'[\s\S]*?recoverOverlayAfterLoadingUpdate\(tab\.id, retryChangeInfo, retryTab\)/,
+  'any transient loading-Document race should refresh the live tab and retry from its actual URL/status'
+);
+assert.match(
+  preCompleteRetrySource,
+  /chrome\.tabs\.get\(tab\.id,[\s\S]*?retryWithCurrentTab\(currentTab\);/,
+  'a pre-complete retry should re-read the live tab instead of replaying a stale site URL'
+);
+assert.doesNotMatch(
+  preCompleteRetrySource,
+  /\{ status: 'complete' \}/,
+  'a pre-complete retry must retain loading-session tracking for later Document replacement'
+);
+assert.match(
+  backgroundSource,
+  /if \(chrome\.runtime && chrome\.runtime\.lastError\) \{[\s\S]*?if \(isComplete\) \{[\s\S]*?restoreOverlayAfterLoadingDocumentChange\(resolvedTab, record, true\);[\s\S]*?\} else \{[\s\S]*?scheduleOverlayLoadingPreCompleteRetry\(resolvedTab, record\);/,
+  'a failed probe at URL commit should retry before the final load event'
+);
+assert.match(
+  backgroundSource,
+  /if \(!ok\) \{[\s\S]*?loading-recovery-failed[\s\S]*?scheduleOverlayLoadingPreCompleteRetry\(tab, record\);/,
+  'a failed injection at URL commit should also retry while the target is still loading'
+);
+const openOverlayStart = backgroundSource.indexOf('function openOverlayOnTab(');
+const openOverlaySource = backgroundSource.slice(openOverlayStart, triggerStart);
+assert.match(
+  openOverlaySource,
+  /overlayOpening = beginOverlayOpening\(activeTab, source\);[\s\S]*?if \(!overlayOpening\) \{[\s\S]*?finishOpenAttempt\(false\);[\s\S]*?return;[\s\S]*?rememberOverlayLoadingRecord/,
+  'a concurrent cold start should stop before it can replace loading-session ownership'
+);
+assert.match(
+  openOverlaySource,
+  /if \(\(openOptions\.loadingRecovery === true \|\| shouldRetryPreCompleteFailure\)[\s\S]*?finishOverlayLoadingOpenAttempt\(activeTab\.id\);/,
+  'only an attempt that owns loading recovery should release its in-flight state'
+);
+assert.match(
+  openOverlaySource,
+  /let shouldRetryPreCompleteFailure = false;[\s\S]*?if \(ok !== true[\s\S]*?shouldRetryPreCompleteFailure[\s\S]*?scheduleOverlayLoadingPreCompleteRetry\(activeTab, trackedRecord\);[\s\S]*?const overlayLoadingRecord = rememberOverlayLoadingRecord\(activeTab, source, openOptions\);[\s\S]*?shouldRetryPreCompleteFailure = Boolean\(overlayLoadingRecord\);/,
+  'an initial injection failure in any injectable loading Document should use the same pre-complete retry path'
+);
+assert.match(
+  overlaySource,
+  /if \(ensureOverlayOpen && !shouldReplaceStaleOverlay\) \{[\s\S]*?_x_extension_search_overlay_open_2026_unique_ = true;[\s\S]*?return;/,
+  'a duplicate loading recovery must keep an existing Overlay open instead of toggling it closed'
+);
+assert.match(
+  backgroundSource,
+  /func: \(overlayTabs, overlayPanelContext, overlayHostId\)[\s\S]*?_x_extension_search_overlay_open_2026_unique_[\s\S]*?overlayHost\.isConnected/,
+  'Overlay invocation results should report whether the host remains open in the injected Document'
+);
+assert.match(
+  overlaySource,
+  /function removeOverlay\(overlayElement, options\)[\s\S]*?_x_extension_search_overlay_open_2026_unique_ = false;[\s\S]*?notifyOverlayClosed\(\);/,
+  'intentional Overlay closes should cancel any loading-persistence intent'
 );
 assert.match(
   overlaySource,
@@ -34,7 +190,7 @@ assert.match(
 );
 assert.match(
   overlaySource,
-  /const initialOverlayContentReady = Promise\.all\([\s\S]*?initialOverlayOpenTabsDefaultVisibleReady,[\s\S]*?initialFaviconEnhancedFetchReady[\s\S]*?if \(initialPrefillQuery\)[\s\S]*?requestTabsAndRender\(\)/,
+  /const initialOverlayContentReady = Promise\.all\([\s\S]*?initialOverlayOpenTabsDefaultVisibleReady,[\s\S]*?initialFaviconEnhancedFetchReady[\s\S]*?if \(initialLoadingSession \|\| initialPrefillQuery\)[\s\S]*?requestTabsAndRender\(\)/,
   'non-critical initial content should still hydrate after its preferences are ready'
 );
 const initialContentStart = overlaySource.indexOf('const initialOverlayContentReady = Promise.all([');
@@ -61,8 +217,18 @@ assert.match(
 );
 assert.match(
   initialContentSource,
-  /if \(initialPrefillQuery\)[\s\S]*?return true;[\s\S]*?return initialLanguageReady\.catch\(\(\) => \{\}\)\.then\(\(\) => \{[\s\S]*?requestTabsAndRender\(\);/,
-  'empty-query tab hydration should wait for labels while URL-prefill remains immediate'
+  /if \(initialLoadingSession \|\| initialPrefillQuery\)[\s\S]*?setSelectionRange\([\s\S]*?selectionStart,[\s\S]*?selectionEnd,[\s\S]*?selectionDirection[\s\S]*?return true;[\s\S]*?return initialLanguageReady\.catch\(\(\) => \{\}\)\.then\(\(\) => \{[\s\S]*?requestTabsAndRender\(\);/,
+  'a restored loading session should retain its exact draft and selection before ordinary empty-query hydration'
+);
+assert.match(
+  overlaySource,
+  /function notifyOverlayLoadingSession\(input\)[\s\S]*?action: 'updateOverlayLoadingSession',[\s\S]*?inputValue,[\s\S]*?selectionStart,[\s\S]*?selectionEnd,[\s\S]*?focused:/,
+  'typing in a loading Document should persist the live draft, selection, and focus state'
+);
+assert.match(
+  backgroundSource,
+  /case 'updateOverlayLoadingSession': \{[\s\S]*?updateOverlayLoadingSessionFromMessage\(request, sender, sendResponse\);[\s\S]*?return true;/,
+  'the background router should accept asynchronous loading-session updates from the Overlay'
 );
 assert.doesNotMatch(
   overlaySource.slice(overlaySource.lastIndexOf('const revealReady =')),

--- a/scripts/test-overlay-loading-lifecycle.js
+++ b/scripts/test-overlay-loading-lifecycle.js
@@ -1,0 +1,326 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const lifecycle = require(path.join(
+  __dirname,
+  '..',
+  'src',
+  'background',
+  'overlay-loading-lifecycle.js'
+));
+
+const urlGuardSandbox = { URL };
+urlGuardSandbox.globalThis = urlGuardSandbox;
+vm.runInNewContext(
+  fs.readFileSync(path.join(__dirname, '..', 'src', 'shared', 'url-guards.js'), 'utf8'),
+  urlGuardSandbox,
+  { filename: 'src/shared/url-guards.js' }
+);
+const canInjectOverlayUrl = urlGuardSandbox.LumnoUrlGuards.canOpenOverlayOnUrl;
+
+const loadingTab = {
+  id: 42,
+  status: 'loading',
+  url: 'https://before.example/',
+  pendingUrl: 'https://after.example/'
+};
+const initialRecord = lifecycle.createRecord(loadingTab, 'commands', 1000);
+assert.ok(
+  lifecycle.createRecord({
+    id: 41,
+    status: 'loading',
+    url: 'https://already-committed.example.test/',
+    pendingUrl: ''
+  }, 'commands', 1000),
+  'an already committed HTTP(S) Document should still be tracked until loading completes'
+);
+
+const injectablePendingNavigationCases = [
+  {
+    name: 'reported Google Auth navigation from about:blank',
+    tab: {
+      id: 43,
+      status: 'loading',
+      url: 'about:blank',
+      pendingUrl: 'https://accounts.google.com/o/oauth2/auth'
+    }
+  },
+  {
+    name: 'reported Feishu navigation from the browser New Tab',
+    tab: {
+      id: 44,
+      status: 'loading',
+      url: 'chrome://newtab/',
+      pendingUrl: 'https://www.feishu.cn/'
+    }
+  },
+  {
+    name: 'ordinary HTTP navigation from another Chromium internal page',
+    tab: {
+      id: 45,
+      status: 'loading',
+      url: 'edge://newtab/',
+      pendingUrl: 'http://intranet.example.test/dashboard'
+    }
+  },
+  {
+    name: 'ordinary HTTPS navigation replacing an extension Document',
+    tab: {
+      id: 46,
+      status: 'loading',
+      url: 'chrome-extension://example/src/newtab/newtab.html',
+      pendingUrl: 'https://destination.example.test/path'
+    }
+  },
+  {
+    name: 'ordinary HTTPS navigation before Chrome exposes a current URL',
+    tab: {
+      id: 47,
+      status: 'loading',
+      url: '',
+      pendingUrl: 'https://destination.example.test/early'
+    }
+  }
+];
+
+injectablePendingNavigationCases.forEach(({ name, tab }) => {
+  assert.strictEqual(
+    lifecycle.getPendingInjectableUrl(tab, canInjectOverlayUrl),
+    tab.pendingUrl,
+    `${name} should use the shared deferred-injection rule`
+  );
+});
+
+const nonDeferredNavigationCases = [
+  {
+    name: 'protected browser target',
+    tab: {
+      id: 48,
+      status: 'loading',
+      url: 'chrome://newtab/',
+      pendingUrl: 'chrome://settings/'
+    }
+  },
+  {
+    name: 'browser extension target',
+    tab: {
+      id: 49,
+      status: 'loading',
+      url: 'about:blank',
+      pendingUrl: 'chrome-extension://example/options.html'
+    }
+  },
+  {
+    name: 'browser extension-store target',
+    tab: {
+      id: 50,
+      status: 'loading',
+      url: 'about:blank',
+      pendingUrl: 'https://chromewebstore.google.com/detail/example/abc'
+    }
+  },
+  {
+    name: 'unsupported protocol target',
+    tab: {
+      id: 51,
+      status: 'loading',
+      url: 'about:blank',
+      pendingUrl: 'mailto:hello@example.test'
+    }
+  },
+  {
+    name: 'already injectable current Document',
+    tab: {
+      id: 52,
+      status: 'loading',
+      url: 'https://before.example.test/',
+      pendingUrl: 'https://after.example.test/'
+    }
+  },
+  {
+    name: 'completed restricted Document without a pending target',
+    tab: {
+      id: 53,
+      status: 'complete',
+      url: 'about:blank',
+      pendingUrl: ''
+    }
+  }
+];
+
+nonDeferredNavigationCases.forEach(({ name, tab }) => {
+  assert.strictEqual(
+    lifecycle.getPendingInjectableUrl(tab, canInjectOverlayUrl),
+    '',
+    `${name} should retain the ordinary restricted/current-Document behavior`
+  );
+});
+
+assert.ok(initialRecord, 'a loading tab should keep a temporary Overlay-open intent');
+assert.strictEqual(
+  lifecycle.createRecord({ ...loadingTab, status: 'complete', pendingUrl: '' }, 'commands', 1000),
+  null,
+  'a completed tab should not create loading-persistence state'
+);
+
+const provisionalRecord = lifecycle.createRecord({
+  id: 43,
+  status: 'loading',
+  url: 'about:blank',
+  pendingUrl: 'https://accounts.google.com/o/oauth2/auth'
+}, 'commands', 1000);
+const committedProvisionalTarget = lifecycle.decideRecovery(provisionalRecord, [{
+  frameId: 0,
+  documentId: 'doc-auth',
+  result: {
+    runtimeReady: false,
+    overlayOpenState: 'unknown',
+    overlayConnected: false
+  }
+}], { now: 1050, complete: false });
+assert.strictEqual(
+  committedProvisionalTarget.action,
+  'restore',
+  'committing a deferred target should request injection before loading completes'
+);
+
+const openedInOldDocument = lifecycle.applyInvocationResult(initialRecord, [{
+  frameId: 0,
+  documentId: 'doc-old',
+  result: { ok: true, overlayOpen: true }
+}], 1100);
+assert.strictEqual(openedInOldDocument.action, 'keep');
+assert.strictEqual(openedInOldDocument.record.documentId, 'doc-old');
+
+const typedInOldDocument = lifecycle.applySessionUpdate(
+  openedInOldDocument.record,
+  {
+    inputValue: 'design inspiration',
+    selectionStart: 7,
+    selectionEnd: 18,
+    selectionDirection: 'forward',
+    focused: true
+  },
+  { documentId: 'doc-old', now: 1150 }
+);
+assert.strictEqual(typedInOldDocument.action, 'keep');
+assert.deepStrictEqual(
+  typedInOldDocument.record.session,
+  {
+    inputValue: 'design inspiration',
+    selectionStart: 7,
+    selectionEnd: 18,
+    selectionDirection: 'forward',
+    focused: true,
+    revision: 1,
+    updatedAt: 1150
+  },
+  'the loading record should carry the exact draft, selection, and focus state'
+);
+
+const committedDocument = lifecycle.decideRecovery(typedInOldDocument.record, [{
+  frameId: 0,
+  documentId: 'doc-new',
+  result: {
+    runtimeReady: false,
+    overlayOpenState: 'unknown',
+    overlayConnected: false
+  }
+}], { now: 1200, complete: false });
+assert.strictEqual(
+  committedDocument.action,
+  'restore',
+  'a newly committed Document should restore the Overlay that was open during loading'
+);
+assert.strictEqual(committedDocument.reason, 'document-changed');
+assert.deepStrictEqual(
+  committedDocument.record.session,
+  typedInOldDocument.record.session,
+  'committing a replacement Document must retain the live input session'
+);
+
+const staleOldDocumentUpdate = lifecycle.applySessionUpdate(
+  committedDocument.record,
+  {
+    inputValue: 'stale draft',
+    selectionStart: 11,
+    selectionEnd: 11,
+    focused: false
+  },
+  { documentId: 'doc-old', now: 1275 }
+);
+assert.strictEqual(staleOldDocumentUpdate.reason, 'stale-document');
+assert.deepStrictEqual(
+  staleOldDocumentUpdate.record.session,
+  typedInOldDocument.record.session,
+  'a late message from the replaced Document must not overwrite the retained draft'
+);
+
+const restoredInNewDocument = lifecycle.applyInvocationResult(committedDocument.record, [{
+  frameId: 0,
+  documentId: 'doc-new',
+  result: { ok: true, overlayOpen: true }
+}], 1300);
+const completedInNewDocument = lifecycle.decideRecovery(restoredInNewDocument.record, [{
+  frameId: 0,
+  documentId: 'doc-new',
+  result: {
+    runtimeReady: true,
+    overlayOpenState: 'open',
+    overlayConnected: true
+  }
+}], { now: 1400, complete: true });
+assert.strictEqual(
+  completedInNewDocument.action,
+  'clear',
+  'completion in the restored Document should only clear tracking, never toggle the Overlay again'
+);
+
+const intentionallyClosed = lifecycle.decideRecovery(openedInOldDocument.record, [{
+  frameId: 0,
+  documentId: 'doc-old',
+  result: {
+    runtimeReady: true,
+    overlayOpenState: 'closed',
+    overlayConnected: false
+  }
+}], { now: 1250, complete: true });
+assert.strictEqual(
+  intentionallyClosed.action,
+  'clear',
+  'an intentional close in the same Document must not be reopened at load completion'
+);
+
+const detachedHost = lifecycle.decideRecovery(openedInOldDocument.record, [{
+  frameId: 0,
+  documentId: 'doc-old',
+  result: {
+    runtimeReady: true,
+    overlayOpenState: 'open',
+    overlayConnected: false
+  }
+}], { now: 1250, complete: false });
+assert.strictEqual(
+  detachedHost.action,
+  'restore',
+  'a page-side DOM replacement should restore an Overlay host that disappeared without closing'
+);
+
+const closedStateInNewDocument = lifecycle.decideRecovery(openedInOldDocument.record, [{
+  frameId: 0,
+  documentId: 'doc-new',
+  result: {
+    runtimeReady: true,
+    overlayOpenState: 'closed',
+    overlayConnected: false
+  }
+}], { now: 1250, complete: false });
+assert.strictEqual(
+  closedStateInNewDocument.action,
+  'restore',
+  'a default closed flag in a replacement Document is not an intentional close of the old Overlay'
+);
+
+console.log('overlay loading lifecycle tests passed');

--- a/scripts/test-tab-switcher-hotkeys.js
+++ b/scripts/test-tab-switcher-hotkeys.js
@@ -252,7 +252,7 @@ assert.match(
 );
 const openOverlayBlock = getFunctionBlock(
   backgroundSource,
-  'function openOverlayOnTab(activeTab, tabs, source)',
+  'function openOverlayOnTab(activeTab, tabs, source, options)',
   'function triggerShowSearchForTab(tab, source)'
 );
 assert.match(

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -150,6 +150,12 @@ try {
 }
 
 try {
+  importScripts(chrome.runtime.getURL('src/background/overlay-loading-lifecycle.js'));
+} catch (error) {
+  console.warn('Lumno: failed to load Overlay loading lifecycle helpers.', error);
+}
+
+try {
   importScripts(chrome.runtime.getURL('src/background/dev-extension-startup.js'));
 } catch (error) {
   console.warn('Lumno: failed to load development startup helpers.', error);
@@ -194,6 +200,7 @@ const openNewtabFallback = BACKGROUND_NEWTAB_FALLBACK.openNewtabFallback;
 const openNewtabFallbackForUrl = BACKGROUND_NEWTAB_FALLBACK.openNewtabFallbackForUrl;
 const BACKGROUND_SHORTCUT_RULES = globalThis.LumnoShortcutRules || {};
 const RECENT_TAB_SWITCHER = globalThis.LumnoRecentTabSwitcher || {};
+const OVERLAY_LOADING_LIFECYCLE = globalThis.LumnoOverlayLoadingLifecycle || {};
 const DEV_EXTENSION_STARTUP = globalThis.LumnoDevExtensionStartup || {};
 const CODEX_DEBUG_BRIDGE = globalThis.LumnoCodexDebugBackground || {};
 const codexDebugBridge = CODEX_DEBUG_BRIDGE && typeof CODEX_DEBUG_BRIDGE.create === 'function'
@@ -1649,6 +1656,18 @@ const tabSwitcherOpeningByWindowKey = new Map();
 const TAB_SWITCHER_HOST_STATE_TIMEOUT_MS = 400;
 const tabSwitcherHostTabIdByWindowId = new Map();
 const HOTKEY_DUP_GUARD_MS = 180;
+const OVERLAY_OPENING_GUARD_MS = 5000;
+const OVERLAY_RUNTIME_VERSION = '2026-08-17-loading-session-v6';
+const OVERLAY_HOST_ID = '_x_extension_overlay_host_2026_unique_';
+const OVERLAY_LOADING_RECORD_STORAGE_PREFIX =
+  '_x_extension_overlay_loading_record_2026_unique_:';
+const OVERLAY_LOADING_RECORD_TTL_MS = Number(
+  OVERLAY_LOADING_LIFECYCLE.DEFAULT_RECORD_TTL_MS
+) || (5 * 60 * 1000);
+const OVERLAY_LOADING_RECOVERY_MAX_ATTEMPTS = 3;
+const OVERLAY_LOADING_RECOVERY_RETRY_MS = 120;
+const OVERLAY_LOADING_PRE_COMPLETE_RETRY_MAX_ATTEMPTS = 3;
+const OVERLAY_LOADING_PRE_COMPLETE_RETRY_MS = 120;
 const PAGE_HOTKEY_NEWTAB_RECOVER_MS = 1200;
 const BROWSER_NEWTAB_PROVIDER_DETECTION_MS = 6000;
 const TAB_SWITCHER_LIMIT = 5;
@@ -1678,6 +1697,10 @@ let documentPipEnabledCache = false;
 let tabSwitcherEnabledCache = true;
 let pinnedTabRecoveryEnabledCache = false;
 const hotkeyInvokeAtByTabId = new Map();
+const overlayOpeningByTabId = new Map();
+const overlayLoadingRecordsByTabId = new Map();
+const overlayLoadingRecoveryInFlightByTabId = new Set();
+const overlayLoadingPendingUpdateByTabId = new Map();
 const browserNewtabProviderCandidateTabIds = new Map();
 let lastPageHotkeyContext = null;
 const tabSwitchEventsByTabId = new Map();
@@ -2864,6 +2887,45 @@ function shouldIgnoreDuplicateHotkey(tabId) {
   return (now - lastAt) <= HOTKEY_DUP_GUARD_MS;
 }
 
+function finishOverlayOpening(opening) {
+  if (!opening || typeof opening.tabId !== 'number') {
+    return;
+  }
+  if (opening.timer) {
+    clearTimeout(opening.timer);
+    opening.timer = null;
+  }
+  if (overlayOpeningByTabId.get(opening.tabId) === opening) {
+    overlayOpeningByTabId.delete(opening.tabId);
+  }
+}
+
+function beginOverlayOpening(tab, source) {
+  if (!tab || typeof tab.id !== 'number') {
+    return null;
+  }
+  const existing = overlayOpeningByTabId.get(tab.id);
+  if (existing) {
+    logHotkeyDebug('overlay-opening-guarded', {
+      tabId: tab.id,
+      source: source || '',
+      age: Date.now() - existing.startedAt
+    });
+    return null;
+  }
+  const opening = {
+    tabId: tab.id,
+    source: source || '',
+    startedAt: Date.now(),
+    timer: null
+  };
+  opening.timer = setTimeout(() => {
+    finishOverlayOpening(opening);
+  }, OVERLAY_OPENING_GUARD_MS);
+  overlayOpeningByTabId.set(tab.id, opening);
+  return opening;
+}
+
 function rememberPageHotkeyContext(tab) {
   if (!tab || typeof tab.id !== 'number' || typeof tab.windowId !== 'number') {
     lastPageHotkeyContext = null;
@@ -3926,14 +3988,543 @@ function createTabSwitcherOpeningFinisher(opening) {
   };
 }
 
-function openOverlayOnTab(activeTab, tabs, source) {
+function getOverlayLoadingRecordStorageArea() {
+  return chrome && chrome.storage && chrome.storage.session &&
+    typeof chrome.storage.session.get === 'function'
+    ? chrome.storage.session
+    : null;
+}
+
+function getOverlayLoadingRecordStorageKey(tabId) {
+  return `${OVERLAY_LOADING_RECORD_STORAGE_PREFIX}${tabId}`;
+}
+
+function setOverlayLoadingRecord(record) {
+  if (!record || typeof record.tabId !== 'number') {
+    return;
+  }
+  const currentRecord = overlayLoadingRecordsByTabId.get(record.tabId) || null;
+  const currentSession = currentRecord && currentRecord.session &&
+    typeof currentRecord.session === 'object'
+    ? currentRecord.session
+    : null;
+  const incomingSession = record.session && typeof record.session === 'object'
+    ? record.session
+    : null;
+  const shouldPreserveCurrentSession = Boolean(
+    currentSession &&
+    (!incomingSession ||
+      Number(currentSession.revision || 0) > Number(incomingSession.revision || 0) ||
+      (Number(currentSession.revision || 0) === Number(incomingSession.revision || 0) &&
+        Number(currentSession.updatedAt || 0) > Number(incomingSession.updatedAt || 0)))
+  );
+  const nextRecord = {
+    ...record,
+    session: shouldPreserveCurrentSession ? currentSession : incomingSession
+  };
+  overlayLoadingRecordsByTabId.set(record.tabId, nextRecord);
+  const sessionArea = getOverlayLoadingRecordStorageArea();
+  if (!sessionArea || typeof sessionArea.set !== 'function') {
+    return;
+  }
+  try {
+    sessionArea.set({
+      [getOverlayLoadingRecordStorageKey(record.tabId)]: nextRecord
+    }, () => {
+      void chrome.runtime.lastError;
+    });
+  } catch (error) {
+    // The in-memory record still covers ordinary loading lifetimes.
+  }
+}
+
+function clearOverlayLoadingRecord(tabId) {
+  if (typeof tabId !== 'number') {
+    return;
+  }
+  overlayLoadingRecordsByTabId.delete(tabId);
+  overlayLoadingRecoveryInFlightByTabId.delete(tabId);
+  overlayLoadingPendingUpdateByTabId.delete(tabId);
+  const sessionArea = getOverlayLoadingRecordStorageArea();
+  if (!sessionArea || typeof sessionArea.remove !== 'function') {
+    return;
+  }
+  try {
+    sessionArea.remove(getOverlayLoadingRecordStorageKey(tabId), () => {
+      void chrome.runtime.lastError;
+    });
+  } catch (error) {
+    // Ignore session-storage cleanup failures.
+  }
+}
+
+function getOverlayLoadingRecord(tabId, callback) {
+  const done = typeof callback === 'function' ? callback : () => {};
+  if (typeof tabId !== 'number') {
+    done(null);
+    return;
+  }
+  const cached = overlayLoadingRecordsByTabId.get(tabId) || null;
+  if (cached) {
+    if (typeof OVERLAY_LOADING_LIFECYCLE.isExpired === 'function' &&
+        OVERLAY_LOADING_LIFECYCLE.isExpired(
+          cached,
+          Date.now(),
+          OVERLAY_LOADING_RECORD_TTL_MS
+        )) {
+      clearOverlayLoadingRecord(tabId);
+      done(null);
+      return;
+    }
+    done(cached);
+    return;
+  }
+  const sessionArea = getOverlayLoadingRecordStorageArea();
+  if (!sessionArea) {
+    done(null);
+    return;
+  }
+  const storageKey = getOverlayLoadingRecordStorageKey(tabId);
+  try {
+    sessionArea.get(storageKey, (result) => {
+      if (chrome.runtime && chrome.runtime.lastError) {
+        done(null);
+        return;
+      }
+      const stored = result && result[storageKey] && typeof result[storageKey] === 'object'
+        ? result[storageKey]
+        : null;
+      if (!stored || stored.tabId !== tabId ||
+          (typeof OVERLAY_LOADING_LIFECYCLE.isExpired === 'function' &&
+            OVERLAY_LOADING_LIFECYCLE.isExpired(
+              stored,
+              Date.now(),
+              OVERLAY_LOADING_RECORD_TTL_MS
+            ))) {
+        if (stored) {
+          clearOverlayLoadingRecord(tabId);
+        }
+        done(null);
+        return;
+      }
+      overlayLoadingRecordsByTabId.set(tabId, stored);
+      done(stored);
+    });
+  } catch (error) {
+    done(null);
+  }
+}
+
+function rememberOverlayLoadingRecord(activeTab, source, options) {
+  const settings = options && typeof options === 'object' ? options : {};
+  if (settings.loadingRecovery === true) {
+    return settings.loadingRecord || overlayLoadingRecordsByTabId.get(activeTab.id) || null;
+  }
+  const record = typeof OVERLAY_LOADING_LIFECYCLE.createRecord === 'function'
+    ? OVERLAY_LOADING_LIFECYCLE.createRecord(activeTab, source, Date.now())
+    : null;
+  if (!record) {
+    clearOverlayLoadingRecord(activeTab.id);
+    return null;
+  }
+  setOverlayLoadingRecord(record);
+  overlayLoadingRecoveryInFlightByTabId.add(activeTab.id);
+  return record;
+}
+
+function getPendingOverlayNavigationUrl(tab) {
+  if (typeof OVERLAY_LOADING_LIFECYCLE.getPendingInjectableUrl === 'function') {
+    return OVERLAY_LOADING_LIFECYCLE.getPendingInjectableUrl(
+      tab,
+      canOpenOverlayOnUrl
+    );
+  }
+  if (!tab || typeof tab.id !== 'number') {
+    return '';
+  }
+  const currentUrl = typeof tab.url === 'string' ? tab.url.trim() : '';
+  const pendingUrl = typeof tab.pendingUrl === 'string' ? tab.pendingUrl.trim() : '';
+  const isLoading = tab.status === 'loading' || Boolean(pendingUrl);
+  if (!isLoading || !pendingUrl || canOpenOverlayOnUrl(currentUrl) ||
+      !canOpenOverlayOnUrl(pendingUrl)) {
+    return '';
+  }
+  return pendingUrl;
+}
+
+function rememberOverlayPendingNavigationIntent(activeTab, source, pendingUrl) {
+  if (!activeTab || typeof activeTab.id !== 'number' || !pendingUrl) {
+    return null;
+  }
+  const record = typeof OVERLAY_LOADING_LIFECYCLE.createRecord === 'function'
+    ? OVERLAY_LOADING_LIFECYCLE.createRecord(activeTab, source, Date.now())
+    : null;
+  if (!record) {
+    return null;
+  }
+  const currentRecord = overlayLoadingRecordsByTabId.get(activeTab.id) || null;
+  const nextRecord = {
+    ...record,
+    documentId: currentRecord && currentRecord.documentId
+      ? currentRecord.documentId
+      : record.documentId,
+    session: currentRecord && currentRecord.session
+      ? currentRecord.session
+      : record.session,
+    pendingNavigationUrl: pendingUrl
+  };
+  setOverlayLoadingRecord(nextRecord);
+  logHotkeyDebug('overlay-deferred-for-pending-navigation', {
+    tabId: activeTab.id,
+    currentUrl: typeof activeTab.url === 'string' ? activeTab.url : '',
+    pendingUrl,
+    source: source || ''
+  });
+  return nextRecord;
+}
+
+function queueOverlayLoadingUpdate(tabId, changeInfo, tab) {
+  const current = overlayLoadingPendingUpdateByTabId.get(tabId) || null;
+  const incomingComplete = Boolean(changeInfo && changeInfo.status === 'complete');
+  const currentComplete = Boolean(current && current.changeInfo &&
+    current.changeInfo.status === 'complete');
+  if (currentComplete && !incomingComplete) {
+    return;
+  }
+  overlayLoadingPendingUpdateByTabId.set(tabId, {
+    changeInfo: { ...(changeInfo || {}) },
+    tab: tab ? { ...tab } : null
+  });
+}
+
+function finishOverlayLoadingOpenAttempt(tabId) {
+  if (typeof tabId !== 'number' ||
+      !overlayLoadingRecoveryInFlightByTabId.has(tabId)) {
+    return;
+  }
+  overlayLoadingRecoveryInFlightByTabId.delete(tabId);
+  const pendingUpdate = overlayLoadingPendingUpdateByTabId.get(tabId) || null;
+  overlayLoadingPendingUpdateByTabId.delete(tabId);
+  if (!pendingUpdate) {
+    return;
+  }
+  setTimeout(() => {
+    recoverOverlayAfterLoadingUpdate(
+      tabId,
+      pendingUpdate.changeInfo,
+      pendingUpdate.tab
+    );
+  }, 0);
+}
+
+function updateOverlayLoadingRecordFromInvocation(activeTab, results) {
+  if (!activeTab || typeof activeTab.id !== 'number') {
+    return;
+  }
+  const record = overlayLoadingRecordsByTabId.get(activeTab.id) || null;
+  if (!record || typeof OVERLAY_LOADING_LIFECYCLE.applyInvocationResult !== 'function') {
+    return;
+  }
+  const outcome = OVERLAY_LOADING_LIFECYCLE.applyInvocationResult(
+    record,
+    results,
+    Date.now()
+  );
+  if (!outcome || outcome.action === 'clear') {
+    clearOverlayLoadingRecord(activeTab.id);
+    return;
+  }
+  if (outcome.record) {
+    setOverlayLoadingRecord(outcome.record);
+  }
+}
+
+function updateOverlayLoadingSessionFromMessage(request, sender, sendResponse) {
+  const senderTab = sender && sender.tab ? sender.tab : null;
+  if (!senderTab || typeof senderTab.id !== 'number' ||
+      (typeof sender.frameId === 'number' && sender.frameId !== 0)) {
+    sendResponse({ ok: false, tracked: false });
+    return;
+  }
+  getOverlayLoadingRecord(senderTab.id, (record) => {
+    if (!record || typeof OVERLAY_LOADING_LIFECYCLE.applySessionUpdate !== 'function') {
+      sendResponse({ ok: true, tracked: false });
+      return;
+    }
+    const outcome = OVERLAY_LOADING_LIFECYCLE.applySessionUpdate(
+      record,
+      request && request.session,
+      {
+        documentId: sender && typeof sender.documentId === 'string'
+          ? sender.documentId
+          : '',
+        now: Date.now()
+      }
+    );
+    if (!outcome || !outcome.record) {
+      sendResponse({ ok: true, tracked: false });
+      return;
+    }
+    setOverlayLoadingRecord(outcome.record);
+    sendResponse({
+      ok: true,
+      tracked: outcome.reason !== 'stale-document'
+    });
+  });
+}
+
+function probeOverlayLoadingState(tabId, callback) {
+  chrome.scripting.executeScript({
+    target: { tabId },
+    injectImmediately: true,
+    func: (runtimeVersion, hostId) => {
+      const rawOpenState = window._x_extension_search_overlay_open_2026_unique_;
+      const host = document.getElementById(hostId);
+      return {
+        runtimeReady:
+          window._x_extension_search_overlay_runtime_version_2026_unique_ === runtimeVersion &&
+          typeof window._x_extension_toggleSearchOverlay_2026_unique_ === 'function',
+        overlayOpenState: rawOpenState === true
+          ? 'open'
+          : (rawOpenState === false ? 'closed' : 'unknown'),
+        overlayConnected: Boolean(host && host.isConnected)
+      };
+    },
+    args: [OVERLAY_RUNTIME_VERSION, OVERLAY_HOST_ID]
+  }, callback);
+}
+
+function scheduleOverlayLoadingRecoveryRetry(tab, record) {
+  if (!tab || typeof tab.id !== 'number' || !record) {
+    return;
+  }
+  const recoveryAttempts = Math.max(0, Number(record.recoveryAttempts) || 0) + 1;
+  if (recoveryAttempts > OVERLAY_LOADING_RECOVERY_MAX_ATTEMPTS) {
+    clearOverlayLoadingRecord(tab.id);
+    return;
+  }
+  const nextRecord = {
+    ...record,
+    recoveryAttempts,
+    updatedAt: Date.now()
+  };
+  setOverlayLoadingRecord(nextRecord);
+  setTimeout(() => {
+    recoverOverlayAfterLoadingUpdate(tab.id, { status: 'complete' }, tab);
+  }, OVERLAY_LOADING_RECOVERY_RETRY_MS * recoveryAttempts);
+}
+
+function scheduleOverlayLoadingPreCompleteRetry(tab, record) {
+  if (!tab || typeof tab.id !== 'number' || !record) {
+    return;
+  }
+  const committedUrl = getResolvedTabUrl(tab);
+  if (!canOpenOverlayOnUrl(committedUrl)) {
+    return;
+  }
+  const currentRecord = overlayLoadingRecordsByTabId.get(tab.id) || record;
+  const previousAttempts = currentRecord.preCompleteRetryUrl === committedUrl
+    ? Math.max(0, Number(currentRecord.preCompleteRecoveryAttempts) || 0)
+    : 0;
+  const preCompleteRecoveryAttempts = previousAttempts + 1;
+  if (preCompleteRecoveryAttempts > OVERLAY_LOADING_PRE_COMPLETE_RETRY_MAX_ATTEMPTS) {
+    logHotkeyDebug('loading-pre-complete-retry-paused', {
+      tabId: tab.id,
+      url: committedUrl,
+      source: currentRecord.source || ''
+    });
+    return;
+  }
+  const nextRecord = {
+    ...currentRecord,
+    preCompleteRetryUrl: committedUrl,
+    preCompleteRecoveryAttempts,
+    updatedAt: Date.now()
+  };
+  setOverlayLoadingRecord(nextRecord);
+  setTimeout(() => {
+    getOverlayLoadingRecord(tab.id, (latestRecord) => {
+      if (!latestRecord || latestRecord.preCompleteRetryUrl !== committedUrl ||
+          Number(latestRecord.preCompleteRecoveryAttempts) !== preCompleteRecoveryAttempts) {
+        return;
+      }
+      const retryWithCurrentTab = (currentTab) => {
+        const stillTracked = overlayLoadingRecordsByTabId.get(tab.id) || null;
+        if (!stillTracked || stillTracked.preCompleteRetryUrl !== committedUrl ||
+            Number(stillTracked.preCompleteRecoveryAttempts) !== preCompleteRecoveryAttempts) {
+          return;
+        }
+        const retryTab = currentTab && typeof currentTab === 'object'
+          ? currentTab
+          : tab;
+        const retryUrl = getResolvedTabUrl(retryTab);
+        if (!canOpenOverlayOnUrl(retryUrl)) {
+          return;
+        }
+        const retryChangeInfo = retryTab.status === 'complete'
+          ? { status: retryTab.status }
+          : { url: retryUrl };
+        recoverOverlayAfterLoadingUpdate(tab.id, retryChangeInfo, retryTab);
+      };
+      if (chrome.tabs && typeof chrome.tabs.get === 'function') {
+        chrome.tabs.get(tab.id, (currentTab) => {
+          if (chrome.runtime && chrome.runtime.lastError) {
+            return;
+          }
+          retryWithCurrentTab(currentTab);
+        });
+        return;
+      }
+      retryWithCurrentTab(tab);
+    });
+  }, OVERLAY_LOADING_PRE_COMPLETE_RETRY_MS * preCompleteRecoveryAttempts);
+}
+
+function restoreOverlayAfterLoadingDocumentChange(tab, record, complete) {
+  if (!tab || typeof tab.id !== 'number' || !record) {
+    return;
+  }
+  openOverlayOnTab(tab, [], record.source, {
+    loadingRecovery: true,
+    loadingRecord: record,
+    ensureOpen: true,
+    skipDuplicateGuard: true,
+    onComplete: (ok) => {
+      if (complete === true) {
+        if (ok) {
+          clearOverlayLoadingRecord(tab.id);
+        } else {
+          scheduleOverlayLoadingRecoveryRetry(tab, record);
+        }
+        return;
+      }
+      if (!ok) {
+        logHotkeyDebug('loading-recovery-failed', {
+          tabId: tab.id,
+          source: record.source || ''
+        });
+        scheduleOverlayLoadingPreCompleteRetry(tab, record);
+      }
+    }
+  });
+}
+
+function recoverOverlayAfterLoadingUpdate(tabId, changeInfo, tab) {
+  const isComplete = Boolean(changeInfo && changeInfo.status === 'complete');
+  const isCommittedUrl = Boolean(changeInfo && typeof changeInfo.url === 'string');
+  if (!isComplete && !isCommittedUrl) {
+    return;
+  }
+  if (overlayLoadingRecoveryInFlightByTabId.has(tabId)) {
+    queueOverlayLoadingUpdate(tabId, changeInfo, tab);
+    return;
+  }
+  getOverlayLoadingRecord(tabId, (record) => {
+    if (!record) {
+      return;
+    }
+    if (overlayLoadingRecoveryInFlightByTabId.has(tabId)) {
+      queueOverlayLoadingUpdate(tabId, changeInfo, tab);
+      return;
+    }
+    const resolvedTab = Object.assign({}, tab || {}, { id: tabId });
+    if (isCommittedUrl) {
+      resolvedTab.url = changeInfo.url;
+    }
+    const resolvedUrl = getResolvedTabUrl(resolvedTab);
+    if (!canOpenOverlayOnUrl(resolvedUrl)) {
+      const trackedPendingUrl = typeof record.pendingNavigationUrl === 'string'
+        ? record.pendingNavigationUrl
+        : '';
+      if (!isComplete && canOpenOverlayOnUrl(trackedPendingUrl)) {
+        return;
+      }
+      clearOverlayLoadingRecord(tabId);
+      return;
+    }
+    overlayLoadingRecoveryInFlightByTabId.add(tabId);
+    probeOverlayLoadingState(tabId, (results) => {
+      if (chrome.runtime && chrome.runtime.lastError) {
+        if (isComplete) {
+          restoreOverlayAfterLoadingDocumentChange(resolvedTab, record, true);
+        } else {
+          finishOverlayLoadingOpenAttempt(tabId);
+          scheduleOverlayLoadingPreCompleteRetry(resolvedTab, record);
+        }
+        return;
+      }
+      const outcome = typeof OVERLAY_LOADING_LIFECYCLE.decideRecovery === 'function'
+        ? OVERLAY_LOADING_LIFECYCLE.decideRecovery(record, results, {
+          complete: isComplete,
+          now: Date.now(),
+          ttlMs: OVERLAY_LOADING_RECORD_TTL_MS
+        })
+        : { action: 'clear', record: null };
+      if (!outcome || outcome.action === 'clear' || outcome.action === 'none') {
+        clearOverlayLoadingRecord(tabId);
+        return;
+      }
+      if (outcome.record) {
+        setOverlayLoadingRecord(outcome.record);
+      }
+      if (outcome.action === 'keep') {
+        finishOverlayLoadingOpenAttempt(tabId);
+        return;
+      }
+      restoreOverlayAfterLoadingDocumentChange(
+        resolvedTab,
+        outcome.record || record,
+        isComplete
+      );
+    });
+  });
+}
+
+function openOverlayOnTab(activeTab, tabs, source, options) {
+  const openOptions = options && typeof options === 'object' ? options : {};
+  let overlayOpening = null;
+  let didFinishOpenAttempt = false;
+  let shouldRetryPreCompleteFailure = false;
+  const finishOpenAttempt = (ok) => {
+    if (didFinishOpenAttempt) {
+      return;
+    }
+    didFinishOpenAttempt = true;
+    if (typeof openOptions.onComplete === 'function') {
+      openOptions.onComplete(ok === true);
+    }
+    if (overlayOpening) {
+      finishOverlayOpening(overlayOpening);
+      overlayOpening = null;
+    }
+    if (ok !== true && openOptions.loadingRecovery !== true &&
+        shouldRetryPreCompleteFailure && activeTab &&
+        typeof activeTab.id === 'number') {
+      const trackedRecord = overlayLoadingRecordsByTabId.get(activeTab.id) || null;
+      if (trackedRecord) {
+        scheduleOverlayLoadingPreCompleteRetry(activeTab, trackedRecord);
+      }
+    }
+    if ((openOptions.loadingRecovery === true || shouldRetryPreCompleteFailure) &&
+        activeTab && typeof activeTab.id === 'number') {
+      finishOverlayLoadingOpenAttempt(activeTab.id);
+    }
+  };
   if (!activeTab || typeof activeTab.id !== 'number') {
     logHotkeyDebug('no-active-tab', { source: source || '' });
     openNewtabFallback();
+    finishOpenAttempt(false);
     return;
   }
-  if (shouldIgnoreDuplicateHotkey(activeTab.id)) {
+  if (openOptions.skipDuplicateGuard !== true && shouldIgnoreDuplicateHotkey(activeTab.id)) {
     logHotkeyDebug('duplicate-ignored', { tabId: activeTab.id, source: source || '' });
+    finishOpenAttempt(false);
+    return;
+  }
+  const pendingNavigationUrl = getPendingOverlayNavigationUrl(activeTab);
+  if (openOptions.loadingRecovery !== true && pendingNavigationUrl &&
+      rememberOverlayPendingNavigationIntent(activeTab, source, pendingNavigationUrl)) {
+    finishOpenAttempt(false);
     return;
   }
   const activeUrl = getResolvedTabUrl(activeTab);
@@ -3950,6 +4541,7 @@ function openOverlayOnTab(activeTab, tabs, source) {
     source: source || ''
   });
   if (restricted) {
+    finishOpenAttempt(false);
     if (isSearchCommandSource(source) && (isLumnoNewtabUrl(activeUrl) || isBrowserNewtabUrl(activeUrl))) {
       requestFocusVisibleNewtabInput(source, activeTab.id);
       return;
@@ -3982,6 +4574,13 @@ function openOverlayOnTab(activeTab, tabs, source) {
     openNewtabFallbackForUrl(activeUrl, { sourceTab: activeTab });
     return;
   }
+  overlayOpening = beginOverlayOpening(activeTab, source);
+  if (!overlayOpening) {
+    finishOpenAttempt(false);
+    return;
+  }
+  const overlayLoadingRecord = rememberOverlayLoadingRecord(activeTab, source, openOptions);
+  shouldRetryPreCompleteFailure = Boolean(overlayLoadingRecord);
   const overlayInjectionFiles = [
     'src/shared/icon-font-preload.js',
     'src/shared/codex-debug-surface.js',
@@ -4016,7 +4615,6 @@ function openOverlayOnTab(activeTab, tabs, source) {
     'src/react/overlay-islands.js',
     'src/overlay/search-panel.js'
   ];
-  const expectedOverlayRuntimeVersion = '2026-08-17-fast-open-v4';
   const runOverlayScript = (tabZoomFactor) => {
       const prefillQuery = getOverlayPrefillQueryForSource(activeTab, source);
       const prioritizeCurrentPageMatch = source === 'page-hotkey-prefill';
@@ -4028,14 +4626,21 @@ function openOverlayOnTab(activeTab, tabs, source) {
         .catch(() => {});
       chrome.scripting.executeScript({
             target: {tabId: activeTab.id},
-            func: (overlayTabs, overlayPanelContext) => {
+            injectImmediately: true,
+            func: (overlayTabs, overlayPanelContext, overlayHostId) => {
               const toggleOverlay = window._x_extension_toggleSearchOverlay_2026_unique_;
               if (typeof toggleOverlay !== 'function') {
                 console.warn('Lumno: overlay search panel helper not available.');
                 return { ok: false, reason: 'search_panel_missing' };
               }
               toggleOverlay(overlayTabs, overlayPanelContext);
-              return { ok: true };
+              const overlayHost = document.getElementById(overlayHostId);
+              return {
+                ok: true,
+                overlayOpen:
+                  window._x_extension_search_overlay_open_2026_unique_ === true &&
+                  Boolean(overlayHost && overlayHost.isConnected)
+              };
             },
             args: [tabs, {
               tabZoomFactor: tabZoomFactor,
@@ -4044,8 +4649,13 @@ function openOverlayOnTab(activeTab, tabs, source) {
               currentTabId: typeof activeTab.id === 'number' ? activeTab.id : null,
               currentTabUrl: getResolvedTabUrl(activeTab),
               documentPipEnabled: documentPipEnabledCache,
-              siteSearchProviders: Array.isArray(siteSearchProviders) ? siteSearchProviders : []
-            }]
+              siteSearchProviders: Array.isArray(siteSearchProviders) ? siteSearchProviders : [],
+              ensureOpen: openOptions.ensureOpen === true,
+              loadingSessionTracked: Boolean(overlayLoadingRecord),
+              loadingSession: overlayLoadingRecord && overlayLoadingRecord.session
+                ? overlayLoadingRecord.session
+                : null
+            }, OVERLAY_HOST_ID]
           }, function(results) {
             if (chrome.runtime.lastError) {
               logHotkeyDebug('inject-failed', {
@@ -4054,10 +4664,17 @@ function openOverlayOnTab(activeTab, tabs, source) {
                 error: chrome.runtime.lastError.message || 'unknown',
                 source: source || ''
               });
-              openNewtabFallback({ sourceTab: activeTab });
+              if (openOptions.loadingRecovery !== true &&
+                  !overlayLoadingRecordsByTabId.has(activeTab.id)) {
+                openNewtabFallback({ sourceTab: activeTab });
+              }
+              finishOpenAttempt(false);
               return;
             }
-            const result = Array.isArray(results) && results[0] ? results[0].result : null;
+            const mainResult = typeof OVERLAY_LOADING_LIFECYCLE.getMainFrameResult === 'function'
+              ? OVERLAY_LOADING_LIFECYCLE.getMainFrameResult(results)
+              : (Array.isArray(results) && results[0] ? results[0] : null);
+            const result = mainResult ? mainResult.result : null;
             if (result && result.ok === false) {
               logHotkeyDebug('inject-failed', {
                 step: 'src/overlay/search-panel.js',
@@ -4065,9 +4682,14 @@ function openOverlayOnTab(activeTab, tabs, source) {
                 error: result.reason || 'unknown',
                 source: source || ''
               });
-              openNewtabFallback({ sourceTab: activeTab });
+              if (openOptions.loadingRecovery !== true &&
+                  !overlayLoadingRecordsByTabId.has(activeTab.id)) {
+                openNewtabFallback({ sourceTab: activeTab });
+              }
+              finishOpenAttempt(false);
               return;
             }
+            updateOverlayLoadingRecordFromInvocation(activeTab, results);
             logHotkeyDebug('overlay-opened', {
               tabId: activeTab.id,
               tabCount: Array.isArray(tabs) ? tabs.length : 0,
@@ -4075,6 +4697,7 @@ function openOverlayOnTab(activeTab, tabs, source) {
               tabZoomFactor: tabZoomFactor,
               siteSearchProviderCount: Array.isArray(siteSearchProviders) ? siteSearchProviders.length : 0
             });
+            finishOpenAttempt(Boolean(result && result.overlayOpen === true));
           });
   };
   const runOverlayWithResolvedZoom = () => {
@@ -4093,6 +4716,7 @@ function openOverlayOnTab(activeTab, tabs, source) {
     logHotkeyDebug('inject-start', { tabId: activeTab.id, file: overlayInjectionFiles.join(','), source: source || '' });
     chrome.scripting.executeScript({
       target: {tabId: activeTab.id},
+      injectImmediately: true,
       files: overlayInjectionFiles
     }, function() {
       if (chrome.runtime.lastError) {
@@ -4102,7 +4726,11 @@ function openOverlayOnTab(activeTab, tabs, source) {
           error: chrome.runtime.lastError.message || 'unknown',
           source: source || ''
         });
-        openNewtabFallbackForUrl(activeUrl, { sourceTab: activeTab });
+        if (openOptions.loadingRecovery !== true &&
+            !overlayLoadingRecordsByTabId.has(activeTab.id)) {
+          openNewtabFallbackForUrl(activeUrl, { sourceTab: activeTab });
+        }
+        finishOpenAttempt(false);
         return;
       }
       runOverlayWithResolvedZoom();
@@ -4110,11 +4738,12 @@ function openOverlayOnTab(activeTab, tabs, source) {
   };
   chrome.scripting.executeScript({
     target: {tabId: activeTab.id},
+    injectImmediately: true,
     func: (runtimeVersion) => {
       return window._x_extension_search_overlay_runtime_version_2026_unique_ === runtimeVersion &&
         typeof window._x_extension_toggleSearchOverlay_2026_unique_ === 'function';
     },
-    args: [expectedOverlayRuntimeVersion]
+    args: [OVERLAY_RUNTIME_VERSION]
   }, (results) => {
     const probeError = chrome.runtime.lastError;
     const runtimeReady = !probeError &&
@@ -4125,7 +4754,7 @@ function openOverlayOnTab(activeTab, tabs, source) {
       logHotkeyDebug('runtime-reused', {
         tabId: activeTab.id,
         source: source || '',
-        version: expectedOverlayRuntimeVersion
+        version: OVERLAY_RUNTIME_VERSION
       });
       runOverlayWithResolvedZoom();
       return;
@@ -4138,6 +4767,10 @@ function triggerShowSearchForTab(tab, source) {
   if (!tab || typeof tab.id !== 'number') {
     logHotkeyDebug('no-active-tab', { source: source || '' });
     openNewtabFallback();
+    return;
+  }
+  if (getPendingOverlayNavigationUrl(tab)) {
+    openOverlayOnTab(tab, [], source);
     return;
   }
   const activeUrl = getResolvedTabUrl(tab);
@@ -5035,6 +5668,11 @@ if (chrome && chrome.windows && chrome.windows.onFocusChanged) {
 
 if (chrome && chrome.tabs && chrome.tabs.onRemoved) {
   chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
+    const overlayOpening = overlayOpeningByTabId.get(tabId);
+    if (overlayOpening) {
+      finishOverlayOpening(overlayOpening);
+    }
+    clearOverlayLoadingRecord(tabId);
     clearTabSwitchStat(tabId);
     removeRecentSwitcherTab(tabId);
     clearGlobalPipOwnerForTabId(tabId);
@@ -5055,6 +5693,7 @@ if (chrome && chrome.tabs && chrome.tabs.onUpdated) {
     if (!changeInfo) {
       return;
     }
+    recoverOverlayAfterLoadingUpdate(tabId, changeInfo, tab);
     if (typeof changeInfo.url === 'string' || changeInfo.status === 'complete') {
       const providerTab = Object.assign({}, tab || {}, {
         id: typeof tabId === 'number' ? tabId : (tab && tab.id),
@@ -5519,6 +6158,8 @@ const BACKGROUND_MESSAGE_ROUTE_GROUPS = Object.freeze({
     actions: [
       'switchToTab',
       'reportTabVisible',
+      'notifyOverlayClosed',
+      'updateOverlayLoadingSession',
       'getTabsForOverlay',
       'trackSearchTab',
       'closeOtherTabsForOverlay'
@@ -5650,6 +6291,18 @@ function handleTabMessage(request, sender, sendResponse) {
       }
       sendResponse({ ok: true });
       return;
+    }
+    case 'notifyOverlayClosed': {
+      const senderTab = sender && sender.tab ? sender.tab : null;
+      if (senderTab && typeof senderTab.id === 'number') {
+        clearOverlayLoadingRecord(senderTab.id);
+      }
+      sendResponse({ ok: true });
+      return;
+    }
+    case 'updateOverlayLoadingSession': {
+      updateOverlayLoadingSessionFromMessage(request, sender, sendResponse);
+      return true;
     }
     case 'getTabsForOverlay': {
       ensureTabSwitchStatsLoaded()

--- a/src/background/overlay-loading-lifecycle.js
+++ b/src/background/overlay-loading-lifecycle.js
@@ -1,0 +1,222 @@
+(function(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  root.LumnoOverlayLoadingLifecycle = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  const DEFAULT_RECORD_TTL_MS = 5 * 60 * 1000;
+  const MAX_INPUT_VALUE_LENGTH = 64 * 1024;
+
+  function isLoadingTab(tab) {
+    if (!tab || typeof tab.id !== 'number') {
+      return false;
+    }
+    return tab.status === 'loading' || Boolean(
+      typeof tab.pendingUrl === 'string' && tab.pendingUrl.trim()
+    );
+  }
+
+  function getPendingInjectableUrl(tab, canInjectUrl) {
+    if (!isLoadingTab(tab) || typeof canInjectUrl !== 'function') {
+      return '';
+    }
+    const currentUrl = typeof tab.url === 'string' ? tab.url.trim() : '';
+    const pendingUrl = typeof tab.pendingUrl === 'string' ? tab.pendingUrl.trim() : '';
+    if (!pendingUrl || canInjectUrl(currentUrl) || !canInjectUrl(pendingUrl)) {
+      return '';
+    }
+    return pendingUrl;
+  }
+
+  function createRecord(tab, source, now) {
+    if (!isLoadingTab(tab)) {
+      return null;
+    }
+    const createdAt = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+    return {
+      tabId: tab.id,
+      source: String(source || ''),
+      documentId: '',
+      session: null,
+      createdAt,
+      updatedAt: createdAt
+    };
+  }
+
+  function clampSelectionOffset(value, inputLength, fallback) {
+    const numeric = Number(value);
+    const resolved = Number.isFinite(numeric) ? Math.trunc(numeric) : fallback;
+    return Math.max(0, Math.min(inputLength, resolved));
+  }
+
+  function normalizeSessionState(value, previousSession, now) {
+    const input = value && typeof value === 'object' ? value : {};
+    const previous = previousSession && typeof previousSession === 'object'
+      ? previousSession
+      : null;
+    const rawInputValue = typeof input.inputValue === 'string'
+      ? input.inputValue
+      : (previous && typeof previous.inputValue === 'string' ? previous.inputValue : '');
+    const inputValue = rawInputValue.slice(0, MAX_INPUT_VALUE_LENGTH);
+    const inputLength = inputValue.length;
+    const previousStart = previous && Number.isFinite(Number(previous.selectionStart))
+      ? Number(previous.selectionStart)
+      : inputLength;
+    const selectionStart = clampSelectionOffset(
+      input.selectionStart,
+      inputLength,
+      Math.min(previousStart, inputLength)
+    );
+    const previousEnd = previous && Number.isFinite(Number(previous.selectionEnd))
+      ? Number(previous.selectionEnd)
+      : selectionStart;
+    const selectionEnd = Math.max(selectionStart, clampSelectionOffset(
+      input.selectionEnd,
+      inputLength,
+      Math.min(previousEnd, inputLength)
+    ));
+    const selectionDirection = input.selectionDirection === 'backward' ||
+      input.selectionDirection === 'forward'
+      ? input.selectionDirection
+      : 'none';
+    const updatedAt = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+    return {
+      inputValue,
+      selectionStart,
+      selectionEnd,
+      selectionDirection,
+      focused: input.focused !== false,
+      revision: Math.max(0, Number(previous && previous.revision) || 0) + 1,
+      updatedAt
+    };
+  }
+
+  function applySessionUpdate(record, value, options) {
+    if (!record) {
+      return { action: 'none', record: null, reason: 'not-tracked' };
+    }
+    const settings = options && typeof options === 'object' ? options : {};
+    const senderDocumentId = typeof settings.documentId === 'string'
+      ? settings.documentId
+      : '';
+    const trackedDocumentId = String(record.documentId || '');
+    if (senderDocumentId && trackedDocumentId && senderDocumentId !== trackedDocumentId) {
+      return { action: 'keep', record, reason: 'stale-document' };
+    }
+    const updatedAt = Number.isFinite(Number(settings.now))
+      ? Number(settings.now)
+      : Date.now();
+    return {
+      action: 'keep',
+      record: {
+        ...record,
+        documentId: trackedDocumentId || senderDocumentId,
+        session: normalizeSessionState(value, record.session, updatedAt),
+        updatedAt
+      },
+      reason: 'session-updated'
+    };
+  }
+
+  function getMainFrameResult(results) {
+    const list = Array.isArray(results) ? results.filter(Boolean) : [];
+    return list.find((item) => item.frameId === 0) || list[0] || null;
+  }
+
+  function withResultDocument(record, result, now) {
+    if (!record) {
+      return null;
+    }
+    const nextDocumentId = result && typeof result.documentId === 'string'
+      ? result.documentId
+      : '';
+    const updatedAt = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+    return {
+      ...record,
+      documentId: nextDocumentId || record.documentId || '',
+      updatedAt
+    };
+  }
+
+  function applyInvocationResult(record, results, now) {
+    if (!record) {
+      return { action: 'none', record: null, reason: 'not-tracked' };
+    }
+    const mainResult = getMainFrameResult(results);
+    const payload = mainResult && mainResult.result && typeof mainResult.result === 'object'
+      ? mainResult.result
+      : null;
+    if (!payload || payload.ok !== true) {
+      return { action: 'keep', record, reason: 'invocation-unconfirmed' };
+    }
+    if (payload.overlayOpen !== true) {
+      return { action: 'clear', record: null, reason: 'overlay-closed' };
+    }
+    return {
+      action: 'keep',
+      record: withResultDocument(record, mainResult, now),
+      reason: 'overlay-open'
+    };
+  }
+
+  function isExpired(record, now, ttlMs) {
+    if (!record) {
+      return true;
+    }
+    const currentTime = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+    const maxAge = Number.isFinite(Number(ttlMs)) && Number(ttlMs) > 0
+      ? Number(ttlMs)
+      : DEFAULT_RECORD_TTL_MS;
+    return currentTime - Number(record.createdAt || 0) > maxAge;
+  }
+
+  function decideRecovery(record, results, options) {
+    const settings = options && typeof options === 'object' ? options : {};
+    const now = Number.isFinite(Number(settings.now)) ? Number(settings.now) : Date.now();
+    if (!record) {
+      return { action: 'none', record: null, reason: 'not-tracked' };
+    }
+    if (isExpired(record, now, settings.ttlMs)) {
+      return { action: 'clear', record: null, reason: 'expired' };
+    }
+    const mainResult = getMainFrameResult(results);
+    const payload = mainResult && mainResult.result && typeof mainResult.result === 'object'
+      ? mainResult.result
+      : null;
+    if (!payload) {
+      return { action: 'restore', record, reason: 'probe-unavailable' };
+    }
+    const nextRecord = withResultDocument(record, mainResult, now);
+    if (payload.overlayConnected === true) {
+      return settings.complete === true
+        ? { action: 'clear', record: null, reason: 'complete-and-connected' }
+        : { action: 'keep', record: nextRecord, reason: 'connected' };
+    }
+    const previousDocumentId = String(record.documentId || '');
+    const currentDocumentId = String(mainResult.documentId || '');
+    const comparableDocumentIds = Boolean(previousDocumentId && currentDocumentId);
+    const documentChanged = comparableDocumentIds && previousDocumentId !== currentDocumentId;
+    if (payload.runtimeReady === true && payload.overlayOpenState === 'closed' && !documentChanged) {
+      return { action: 'clear', record: null, reason: 'closed-in-same-document' };
+    }
+    return {
+      action: 'restore',
+      record: nextRecord,
+      reason: documentChanged ? 'document-changed' : 'overlay-host-lost'
+    };
+  }
+
+  return Object.freeze({
+    DEFAULT_RECORD_TTL_MS,
+    applyInvocationResult,
+    applySessionUpdate,
+    createRecord,
+    decideRecovery,
+    getMainFrameResult,
+    getPendingInjectableUrl,
+    isExpired,
+    isLoadingTab,
+    normalizeSessionState
+  });
+});

--- a/src/overlay/search-panel.js
+++ b/src/overlay/search-panel.js
@@ -1,7 +1,8 @@
 'use strict';
 
 window._x_extension_search_overlay_runtime_version_2026_unique_ =
-  '2026-08-17-fast-open-v4';
+  '2026-08-17-loading-session-v6';
+window._x_extension_search_overlay_open_2026_unique_ = false;
 
 window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayContext) {
   let captureTabHandler = null;
@@ -50,6 +51,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
   let overlaySuggestionRequestSeq = 0;
   let overlayRemoteSuggestionDebounceTimer = null;
   let overlayFirstResultRevealTimer = null;
+  let suppressOverlayLoadingSessionNotification = false;
   const OVERLAY_FIRST_RESULT_REVEAL_DELAY_MS = 120;
   let openInCurrentTabModifierActive = false;
   let openSwitchInNewTabModifierActive = false;
@@ -177,6 +179,37 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
   const initialContextTabUrl = typeof normalizedOverlayContext.currentTabUrl === 'string'
     ? String(normalizedOverlayContext.currentTabUrl).trim()
     : '';
+  const ensureOverlayOpen = normalizedOverlayContext.ensureOpen === true;
+  let loadingSessionTrackingActive = normalizedOverlayContext.loadingSessionTracked === true;
+  const rawLoadingSession = normalizedOverlayContext.loadingSession &&
+    typeof normalizedOverlayContext.loadingSession === 'object'
+    ? normalizedOverlayContext.loadingSession
+    : null;
+  const initialLoadingSession = rawLoadingSession &&
+    typeof rawLoadingSession.inputValue === 'string'
+    ? (() => {
+        const inputValue = rawLoadingSession.inputValue;
+        const inputLength = inputValue.length;
+        const rawStart = Number(rawLoadingSession.selectionStart);
+        const selectionStart = Number.isFinite(rawStart)
+          ? Math.max(0, Math.min(inputLength, Math.trunc(rawStart)))
+          : inputLength;
+        const rawEnd = Number(rawLoadingSession.selectionEnd);
+        const selectionEnd = Number.isFinite(rawEnd)
+          ? Math.max(selectionStart, Math.min(inputLength, Math.trunc(rawEnd)))
+          : selectionStart;
+        return {
+          inputValue,
+          selectionStart,
+          selectionEnd,
+          selectionDirection: rawLoadingSession.selectionDirection === 'backward' ||
+            rawLoadingSession.selectionDirection === 'forward'
+            ? rawLoadingSession.selectionDirection
+            : 'none',
+          focused: rawLoadingSession.focused !== false
+        };
+      })()
+    : null;
   function isLocalFileLikeOverlayUrl(url) {
     if (!url) {
       return false;
@@ -1433,8 +1466,78 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     };
   }
 
+  function notifyOverlayClosed() {
+    if (!chrome || !chrome.runtime || typeof chrome.runtime.sendMessage !== 'function') {
+      return;
+    }
+    try {
+      chrome.runtime.sendMessage({ action: 'notifyOverlayClosed' }, () => {
+        void chrome.runtime.lastError;
+      });
+    } catch (error) {
+      // The document may already be unloading.
+    }
+  }
+
+  function isOverlayInputFocused(input) {
+    if (!input) {
+      return false;
+    }
+    if (document.activeElement === input) {
+      return true;
+    }
+    const root = typeof input.getRootNode === 'function' ? input.getRootNode() : null;
+    return Boolean(root && root.activeElement === input);
+  }
+
+  function notifyOverlayLoadingSession(input) {
+    if (suppressOverlayLoadingSessionNotification || !loadingSessionTrackingActive || !input ||
+        !chrome || !chrome.runtime || typeof chrome.runtime.sendMessage !== 'function') {
+      return;
+    }
+    const inputValue = typeof input.value === 'string' ? input.value : '';
+    const inputLength = inputValue.length;
+    const rawSelectionStart = Number(input.selectionStart);
+    const selectionStart = Number.isFinite(rawSelectionStart)
+      ? Math.max(0, Math.min(inputLength, Math.trunc(rawSelectionStart)))
+      : inputLength;
+    const rawSelectionEnd = Number(input.selectionEnd);
+    const selectionEnd = Number.isFinite(rawSelectionEnd)
+      ? Math.max(selectionStart, Math.min(inputLength, Math.trunc(rawSelectionEnd)))
+      : selectionStart;
+    try {
+      chrome.runtime.sendMessage({
+        action: 'updateOverlayLoadingSession',
+        session: {
+          inputValue,
+          selectionStart,
+          selectionEnd,
+          selectionDirection: input.selectionDirection === 'backward' ||
+            input.selectionDirection === 'forward'
+            ? input.selectionDirection
+            : 'none',
+          focused: isOverlayInputFocused(input)
+        }
+      }, (response) => {
+        if (chrome.runtime.lastError) {
+          return;
+        }
+        if (response && response.tracked === false) {
+          loadingSessionTrackingActive = false;
+        }
+      });
+    } catch (error) {
+      // The loading Document can be replaced between the input event and delivery.
+    }
+  }
+
   // Helper function to remove overlay and clean up styles
-  function removeOverlay(overlayElement) {
+  function removeOverlay(overlayElement, options) {
+    const removalOptions = options && typeof options === 'object' ? options : {};
+    window._x_extension_search_overlay_open_2026_unique_ = false;
+    if (removalOptions.preserveLoadingIntent !== true) {
+      notifyOverlayClosed();
+    }
     clearOverlayEnterAnimationFrames();
     clearOverlayPanelEnterCleanup();
     cancelPendingOverlaySuggestionRequests();
@@ -1705,7 +1808,13 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
   if (overlay) {
     const shouldReplaceStaleOverlay = isStaleOverlay(overlay);
     shouldReplaceExistingOverlay = shouldReplaceStaleOverlay;
-    removeOverlay(overlay);
+    if (ensureOverlayOpen && !shouldReplaceStaleOverlay) {
+      window._x_extension_search_overlay_open_2026_unique_ = true;
+      return;
+    }
+    removeOverlay(overlay, {
+      preserveLoadingIntent: shouldReplaceStaleOverlay
+    });
     if (!shouldReplaceStaleOverlay) {
       return;
     }
@@ -6384,6 +6493,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       runSearchInputEventOnce(event, () => {
         imeKeyGuard.markCompositionEnd(event);
         const liveInput = syncLiveSearchInputFromEvent(event);
+        notifyOverlayLoadingSession(liveInput);
         const rawValue = liveInput ? (liveInput.value || '') : '';
         const query = rawValue.trim();
         updateModeBadge(rawValue);
@@ -6429,6 +6539,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
           inputHistoryController.resetNavigation();
         }
         const liveInput = syncLiveSearchInputFromEvent(event);
+        notifyOverlayLoadingSession(liveInput);
         const rawValue = liveInput ? liveInput.value : '';
         const query = rawValue.trim();
         if (query &&
@@ -6498,6 +6609,12 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
     inputContainer.addEventListener('compositionstart', handleSearchInputCompositionStart, true);
     inputContainer.addEventListener('compositionend', handleSearchInputCompositionEnd, true);
     inputContainer.addEventListener('input', handleSearchInputEvent, true);
+    const handleOverlayLoadingSessionSelection = (event) => {
+      notifyOverlayLoadingSession(syncLiveSearchInputFromEvent(event));
+    };
+    inputContainer.addEventListener('select', handleOverlayLoadingSessionSelection, true);
+    inputContainer.addEventListener('focusin', handleOverlayLoadingSessionSelection, true);
+    inputContainer.addEventListener('pointerup', handleOverlayLoadingSessionSelection, true);
 
     // Add click outside to close functionality
     clickOutsideHandler = function(e) {
@@ -8762,6 +8879,7 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       document.documentElement ||
       document.body;
     overlayMountParent.appendChild(overlayHost);
+    window._x_extension_search_overlay_open_2026_unique_ = true;
     if (typeof overlayHost.showPopover === 'function') {
       try {
         overlayHost.showPopover();
@@ -8790,6 +8908,9 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
           typeof searchInput.focus !== 'function') {
         return;
       }
+      if (initialLoadingSession && initialLoadingSession.focused === false) {
+        return;
+      }
       searchInput.focus({ preventScroll: true });
     }
 
@@ -8801,15 +8922,36 @@ window._x_extension_toggleSearchOverlay_2026_unique_ = function(tabs, overlayCon
       if (!overlay || !overlay.isConnected) {
         return false;
       }
-      if (initialPrefillQuery) {
-        searchInput.value = initialPrefillQuery;
+      if (initialLoadingSession || initialPrefillQuery) {
+        const initialInputValue = initialLoadingSession
+          ? initialLoadingSession.inputValue
+          : initialPrefillQuery;
+        searchInput.value = initialInputValue;
         if (typeof searchInput.setSelectionRange === 'function') {
-          searchInput.setSelectionRange(initialPrefillQuery.length, initialPrefillQuery.length);
+          const selectionStart = initialLoadingSession
+            ? initialLoadingSession.selectionStart
+            : initialInputValue.length;
+          const selectionEnd = initialLoadingSession
+            ? initialLoadingSession.selectionEnd
+            : initialInputValue.length;
+          const selectionDirection = initialLoadingSession
+            ? initialLoadingSession.selectionDirection
+            : 'none';
+          searchInput.setSelectionRange(
+            selectionStart,
+            selectionEnd,
+            selectionDirection
+          );
         }
-        latestRawInputValue = initialPrefillQuery;
-        latestOverlayQuery = initialPrefillQuery.trim();
-        updateModeBadge(initialPrefillQuery);
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+        latestRawInputValue = initialInputValue;
+        latestOverlayQuery = initialInputValue.trim();
+        updateModeBadge(initialInputValue);
+        suppressOverlayLoadingSessionNotification = true;
+        try {
+          searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+        } finally {
+          suppressOverlayLoadingSessionNotification = false;
+        }
         return true;
       }
       return initialLanguageReady.catch(() => {}).then(() => {


### PR DESCRIPTION
## What changed

- run Overlay probing, runtime injection, and activation immediately while a page is still loading
- persist one temporary open intent for any injectable loading tab, including provisional navigations whose current Document is still restricted
- restore the Overlay idempotently when navigation replaces the Document or the page removes its host
- retain the input draft, selection, and focus state across Document replacement
- retry transient loading races against the latest tab state and guard each tab against concurrent cold starts
- use the shared URL capability policy throughout; there are no site-specific host rules

## Root cause

Immediate injection alone only fixed the first half of the race. A navigation can replace the Document after Lumno opens, which destroys the injected host. Some navigations also expose a restricted current URL plus an injectable pendingUrl, so treating only the current URL as authoritative drops the shortcut before the destination commits.

## Impact

Lumno can open during ordinary HTTP(S) loading, survives page completion and Document replacement, and preserves what the user already typed. Protected browser pages, extension pages, extension stores, and unsupported protocols keep the existing fallback behavior.

## Validation

- npm run verify
- 139 legacy test files passed
- 46 React test files / 244 React tests passed
- JavaScript syntax, TypeScript, React builds, bundle syntax, and manifest resources passed
- loading lifecycle matrix covers provisional navigation, committed loading Documents, replacement Documents, intentional close, detached hosts, stale messages, restricted targets, and unsupported protocols

Fixes #44.